### PR TITLE
fix dependency in module account_fiscal_position_rule_stock change st…

### DIFF
--- a/account_fiscal_position_rule_stock/__openerp__.py
+++ b/account_fiscal_position_rule_stock/__openerp__.py
@@ -28,7 +28,7 @@
     'website': 'http://www.akretion.com',
     'depends': [
         'account_fiscal_position_rule',
-        'stock',
+        'stock_account',
     ],
     'data': [
         'views/stock_picking.xml',


### PR DESCRIPTION
After version 8.0 inventory module was divided into two stock and stock_account , the stock_account module is installed automatically because it has the autoinstall attribute, but I think important to make the correct dependence explicit , you can prevent future problems and leave the more readable code.
