### PR TITLE
[9.0][FIX] Return object instead dict when Fiscal Position is False

### DIFF
--- a/account_fiscal_position_rule/models/account_fiscal_position_rule.py
+++ b/account_fiscal_position_rule/models/account_fiscal_position_rule.py
@@ -57,6 +57,7 @@ class AccountFiscalPositionRule(models.Model):
         self.from_country = self.company_id.country_id
         self.from_state = self.company_id.state_id
 
+    @api.multi
     def _map_domain(self, partner, addrs, company, **kwargs):
         from_country = company.partner_id.country_id.id
         from_state = company.partner_id.state_id.id
@@ -98,6 +99,7 @@ class AccountFiscalPositionRule(models.Model):
 
         return domain
 
+    @api.multi
     def fiscal_position_map(self, **kwargs):
         result = self.env['account.fiscal.position.rule']
 
@@ -138,6 +140,7 @@ class AccountFiscalPositionRule(models.Model):
 
         return result
 
+    @api.multi
     def apply_fiscal_mapping(self, **kwargs):
         return self.fiscal_position_map(**kwargs)
 
@@ -192,6 +195,7 @@ class WizardAccountFiscalPositionRule(models.TransientModel):
         default=lambda self: self.env['res.company']._company_default_get(
             'wizard.account.fiscal.position.rule'))
 
+    @api.multi
     def _template_vals(self, template, company_id, fiscal_position_id):
         return {'name': template.name,
                 'description': template.description,

--- a/account_fiscal_position_rule/models/account_fiscal_position_rule.py
+++ b/account_fiscal_position_rule/models/account_fiscal_position_rule.py
@@ -99,7 +99,7 @@ class AccountFiscalPositionRule(models.Model):
         return domain
 
     def fiscal_position_map(self, **kwargs):
-        result = {'fiscal_position_id': False}
+        result = self.env['account.fiscal.position.rule']
 
         obj_partner_id = kwargs.get('partner_id')
         obj_company_id = kwargs.get('company_id')
@@ -192,8 +192,7 @@ class WizardAccountFiscalPositionRule(models.TransientModel):
         default=lambda self: self.env['res.company']._company_default_get(
             'wizard.account.fiscal.position.rule'))
 
-    def _template_vals(self, cr, uid, template, company_id,
-                       fiscal_position_id, context=None):
+    def _template_vals(self, template, company_id, fiscal_position_id):
         return {'name': template.name,
                 'description': template.description,
                 'from_country': template.from_country.id,

--- a/account_fiscal_position_rule/test/account_fiscal_position_rule_data.xml
+++ b/account_fiscal_position_rule/test/account_fiscal_position_rule_data.xml
@@ -18,3 +18,4 @@
 
     </data>
 </openerp>
+

--- a/account_fiscal_position_rule/test/account_fiscal_position_rule_data.xml
+++ b/account_fiscal_position_rule/test/account_fiscal_position_rule_data.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data>
+    <data>
 
-		<!-- = = = = = = = = = = = = = = = -->
-		 <!-- Fiscal Mapping Templates     -->
-		<!-- = = = = = = = = = = = = = = = -->
+        <!-- = = = = = = = = = = = = = = = -->
+         <!-- Fiscal Mapping Templates     -->
+        <!-- = = = = = = = = = = = = = = = -->
 
-		<record id="fiscal_position_normal_taxes_template1" model="account.fiscal.position.template">
-			<field name="name">Normal Taxes</field>
-			<field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template"/>
-		</record>
+        <record id="fiscal_position_normal_taxes_template1" model="account.fiscal.position.template">
+            <field name="name">Normal Taxes</field>
+            <field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template"/>
+        </record>
 
-		<record id="fiscal_position_tax_exempt_template2" model="account.fiscal.position.template">
-			<field name="name">Tax Exempt</field>
-			<field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template"/>
-		</record>
+        <record id="fiscal_position_tax_exempt_template2" model="account.fiscal.position.template">
+            <field name="name">Tax Exempt</field>
+            <field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template"/>
+        </record>
 
-	</data>
+    </data>
 </openerp>

--- a/account_fiscal_position_rule/test/test_rules.yml
+++ b/account_fiscal_position_rule/test/test_rules.yml
@@ -103,3 +103,4 @@
 -
   !assert {model: account.invoice, id: invoice_order_test, string: The onchange function of partner was not correctly triggered}:
     - fiscal_position_id.id != False
+

--- a/account_fiscal_position_rule/views/account_fiscal_position_rule_view.xml
+++ b/account_fiscal_position_rule/views/account_fiscal_position_rule_view.xml
@@ -61,7 +61,6 @@
                     <field name="to_invoice_state"/>
                     <field name="to_shipping_country"/>
                     <field name="to_shipping_state"/>
-                    <field name="sequence"/>
                     <field name="vat_rule"/>
                 </tree>
             </field>


### PR DESCRIPTION
When Fiscal Position not found the method need to return a Object instead Dictionary. Besides the fix I removed parameters not used in new API ( cr, uid and context ) and replace Tabs to Space in Data File.

The Migrations PRs  https://github.com/OCA/account-fiscal-rule/pull/47 https://github.com/OCA/account-fiscal-rule/pull/48 https://github.com/OCA/account-fiscal-rule/pull/49 depends of this fix to pass the tests.