### PR TITLE
[FIX] Resolve compatibility issues with odoo standard.

### DIFF
--- a/account_fiscal_position_rule_purchase/models/purchase.py
+++ b/account_fiscal_position_rule_purchase/models/purchase.py
@@ -15,6 +15,17 @@ class PurchaseOrder(models.Model):
         return self.env['account.fiscal.position.rule'].with_context(
             ctx).apply_fiscal_mapping(**kwargs)
 
+    # We already handle the odoo default behaviour, cancel it to prevent conflicts
+    @api.onchange('partner_id', 'company_id')
+    def onchange_partner_id(self):
+        if not self.partner_id:
+            self.payment_term_id = False
+            self.currency_id = False
+        else:
+            self.payment_term_id = self.partner_id.property_supplier_payment_term_id.id
+            self.currency_id = self.partner_id.property_purchase_currency_id.id or self.env.user.company_id.currency_id.id
+        return {}
+
     @api.onchange('partner_id', 'dest_address_id', 'company_id')
     def onchange_fiscal_position_map(self):
 

--- a/account_fiscal_position_rule_sale/models/sale.py
+++ b/account_fiscal_position_rule_sale/models/sale.py
@@ -19,6 +19,11 @@ class SaleOrder(models.Model):
         return self.env['account.fiscal.position.rule'].with_context(
             ctx).apply_fiscal_mapping(**kwargs)
 
+    # We already handle the odoo default behaviour, cancel it to prevent conflicts
+    @api.onchange('partner_shipping_id', 'partner_id')
+    def onchange_partner_shipping_id(self):
+        return {}
+
     @api.onchange('partner_id', 'partner_invoice_id',
                   'partner_shipping_id', 'company_id')
     def onchange_fiscal_position_map(self):


### PR DESCRIPTION
By default, setting the account fiscal position is already done by odoo itself.

The account fiscal modules cause a conflict with the odoo sources which can break the entire functionality of the fiscal modules by having the wrong onchange simply overwriting all the results.