### PR TITLE
[FIX] make onchange raising if there are on taxes fields

### DIFF
--- a/account_product_fiscal_classification/models/__init__.py
+++ b/account_product_fiscal_classification/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import product_template
+from . import product_product
 from . import account_product_fiscal_classification_model
 from . import account_product_fiscal_classification_template
 from . import account_product_fiscal_classification

--- a/account_product_fiscal_classification/models/product_product.py
+++ b/account_product_fiscal_classification/models/product_product.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+# Copyright (C) 2018 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.onchange('fiscal_classification_id')
+    def onchange_fiscal_classification_id(self):
+        fc = self.fiscal_classification_id
+        self.supplier_taxes_id = [[6, 0, fc.purchase_tax_ids.ids]]
+        self.taxes_id = [[6, 0, fc.sale_tax_ids.ids]]

--- a/account_product_fiscal_classification/models/product_template.py
+++ b/account_product_fiscal_classification/models/product_template.py
@@ -76,6 +76,12 @@ class ProductTemplate(models.Model):
                 res['arch'] = etree.tostring(doc)
         return res
 
+    @api.onchange('fiscal_classification_id')
+    def onchange_fiscal_classification_id(self):
+        fc = self.fiscal_classification_id
+        self.supplier_taxes_id = [[6, 0, fc.purchase_tax_ids.ids]]
+        self.taxes_id = [[6, 0, fc.sale_tax_ids.ids]]
+
     # Custom Section
     def write_taxes_setting(self, vals):
         """If Fiscal Classification is defined, set the according taxes
@@ -91,7 +97,7 @@ class ProductTemplate(models.Model):
                     x.id for x in fc.purchase_tax_ids]]],
                 'taxes_id': [[6, 0, [
                     x.id for x in fc.sale_tax_ids]]],
-                }
+            }
             super(ProductTemplate, self.sudo()).write(tax_vals)
         elif 'supplier_taxes_id' in vals.keys() or 'taxes_id' in vals.keys():
             # product template Single update mode


### PR DESCRIPTION
Trivial patch. With the current design, if a onchange is set on taxes, it is not raised. (exemple, this module fail to update correctly standard_margin if fiscal_classification fail) 
with that patch, the on change is working.

thanks for your review.

CC : @quentinDupont, @rvalyi 