### PR TITLE
[13.0] [IMP] Account Fiscal Position Rule: use country groups

### DIFF
--- a/account_fiscal_position_rule/models/account_fiscal_position_rule.py
+++ b/account_fiscal_position_rule/models/account_fiscal_position_rule.py
@@ -19,12 +19,24 @@ class AccountFiscalPositionRule(models.Model):
 
     description = fields.Char(string="Description")
 
+    from_country_group_id = fields.Many2one(
+        string="Country group from",
+        comodel_name="res.country.group",
+        ondelete="restrict",
+    )
+
     from_country = fields.Many2one(comodel_name="res.country", string="Country From")
 
     from_state = fields.Many2one(
         comodel_name="res.country.state",
         string="State From",
         domain="[('country_id', '=', from_country)]",
+    )
+
+    to_invoice_country_group_id = fields.Many2one(
+        string="Invoice Country Group",
+        comodel_name="res.country.group",
+        ondelete="restrict",
     )
 
     to_invoice_country = fields.Many2one(
@@ -35,6 +47,12 @@ class AccountFiscalPositionRule(models.Model):
         comodel_name="res.country.state",
         string="Invoice State",
         domain="[('country_id','=',to_invoice_country)]",
+    )
+
+    to_shipping_country_group_id = fields.Many2one(
+        string="Destination Country Group",
+        comodel_name="res.country.group",
+        ondelete="restrict",
     )
 
     to_shipping_country = fields.Many2one(
@@ -95,14 +113,50 @@ class AccountFiscalPositionRule(models.Model):
         ),
     )
 
+    @api.onchange("from_country_group_id")
+    def _onchange_from_country_group_id(self):
+        self.ensure_one()
+        self.from_country = False
+        if not self.from_country_group_id:
+            from_country_domain = []
+        else:
+            from_country_domain = [
+                ("country_group_ids", "in", self.from_country_group_id.id)
+            ]
+        return {"domain": {"from_country": from_country_domain}}
+
+    @api.onchange("to_invoice_country_group_id")
+    def _onchange_to_invoice_country_group_id(self):
+        self.ensure_one()
+        self.to_invoice_country = False
+        if not self.to_invoice_country_group_id:
+            to_invoice_country_domain = []
+        else:
+            to_invoice_country_domain = [
+                ("country_group_ids", "in", self.to_invoice_country_group_id.id)
+            ]
+        return {"domain": {"to_invoice_country": to_invoice_country_domain}}
+
+    @api.onchange("to_shipping_country_group_id")
+    def _onchange_to_shipping_country_group_id(self):
+        self.ensure_one()
+        self.to_shipping_country = False
+        if not self.to_shipping_country_group_id:
+            to_shipping_country_domain = []
+        else:
+            to_shipping_country_domain = [
+                ("country_group_ids", "in", self.to_shipping_country_group_id.id)
+            ]
+        return {"domain": {"to_shipping_country": to_shipping_country_domain}}
+
     @api.onchange("company_id")
     def onchange_company(self):
         self.from_country = self.company_id.country_id
         self.from_state = self.company_id.state_id
 
     def _map_domain(self, partner, addrs, company, **kwargs):
-        from_country = company.partner_id.country_id.id
-        from_state = company.partner_id.state_id.id
+        from_country = company.partner_id.country_id
+        from_state = company.partner_id.state_id
 
         document_date = self.env.context.get("date", time.strftime("%Y-%m-%d"))
         use_domain = self.env.context.get("use_domain", ("use_sale", "=", True))
@@ -112,10 +166,13 @@ class AccountFiscalPositionRule(models.Model):
             ("company_id", "=", company.id),
             use_domain,
             "|",
-            ("from_country", "=", from_country),
+            ("from_country_group_id", "in", from_country.country_group_ids.ids),
+            ("from_country_group_id", "=", False),
+            "|",
+            ("from_country", "=", from_country.id),
             ("from_country", "=", False),
             "|",
-            ("from_state", "=", from_state),
+            ("from_state", "=", from_state.id),
             ("from_state", "=", False),
             "|",
             ("date_start", "=", False),
@@ -134,13 +191,22 @@ class AccountFiscalPositionRule(models.Model):
             ]
 
         for address_type, address in addrs.items():
+            key_country_group = "to_%s_country_group_id" % address_type
             key_country = "to_%s_country" % address_type
             key_state = "to_%s_state" % address_type
-            to_country = address.country_id.id or False
-            domain += ["|", (key_country, "=", to_country), (key_country, "=", False)]
-            to_state = address.state_id.id or False
-            domain += ["|", (key_state, "=", to_state), (key_state, "=", False)]
-
+            to_country = address.country_id or self.env["res.country"].browse()
+            domain += [
+                "|",
+                (key_country_group, "in", to_country.country_group_ids.ids),
+                (key_country_group, "=", False),
+            ]
+            domain += [
+                "|",
+                (key_country, "=", to_country.id),
+                (key_country, "=", False),
+            ]
+            to_state = address.state_id or self.env["res.country.state"].browse()
+            domain += ["|", (key_state, "=", to_state.id), (key_state, "=", False)]
         return domain
 
     def fiscal_position_map(self, **kwargs):

--- a/account_fiscal_position_rule/views/account_fiscal_position_rule_template_view.xml
+++ b/account_fiscal_position_rule/views/account_fiscal_position_rule_template_view.xml
@@ -18,15 +18,18 @@
                         <field name="description" />
                     </group>
                     <group string="Origin" name="origin" colspan="4">
+                        <field name="from_country_group_id" />
                         <field name="from_country" />
                         <field name="from_state" />
                     </group>
                     <group string="Destination" name="destination">
                         <group string="Invoice">
+                            <field name="to_invoice_country_group_id" />
                             <field name="to_invoice_country" />
                             <field name="to_invoice_state" />
                         </group>
                         <group string="Shipping" name="shipping">
+                            <field name="to_shipping_country_group_id" />
                             <field name="to_shipping_country" />
                             <field name="to_shipping_state" />
                         </group>
@@ -54,10 +57,13 @@
             <tree string="Fiscal Position Rule Template">
                 <field name="sequence" widget="handle" />
                 <field name="name" />
+                <field name="from_country_group_id" />
                 <field name="from_country" />
                 <field name="from_state" />
+                <field name="to_invoice_country_group_id" />
                 <field name="to_invoice_country" />
                 <field name="to_invoice_state" />
+                <field name="to_shipping_country_group_id" />
                 <field name="to_shipping_country" />
                 <field name="to_shipping_state" />
                 <field name="vat_rule" />

--- a/account_fiscal_position_rule/views/account_fiscal_position_rule_view.xml
+++ b/account_fiscal_position_rule/views/account_fiscal_position_rule_view.xml
@@ -12,15 +12,18 @@
                     </group>
                     <group string="Origin" name="origin" colspan="4">
                         <field name="company_id" />
+                        <field name="from_country_group_id" />
                         <field name="from_country" />
                         <field name="from_state" />
                     </group>
                     <group string="Destination" name="destination">
                         <group string="Invoice" name="invoice">
+                            <field name="to_invoice_country_group_id" />
                             <field name="to_invoice_country" />
                             <field name="to_invoice_state" />
                         </group>
                         <group string="Shipping" name="shipping">
+                            <field name="to_shipping_country_group_id" />
                             <field name="to_shipping_country" />
                             <field name="to_shipping_state" />
                         </group>
@@ -49,10 +52,13 @@
                 <field name="sequence" widget="handle" />
                 <field name="company_id" />
                 <field name="name" />
+                <field name="from_country_group_id" />
                 <field name="from_country" />
                 <field name="from_state" />
+                <field name="to_invoice_country_group_id" />
                 <field name="to_invoice_country" />
                 <field name="to_invoice_state" />
+                <field name="to_shipping_country_group_id" />
                 <field name="to_shipping_country" />
                 <field name="to_shipping_state" />
                 <field name="vat_rule" />

--- a/account_fiscal_position_rule/wizard/wizard_account_fiscal_position_rule.py
+++ b/account_fiscal_position_rule/wizard/wizard_account_fiscal_position_rule.py
@@ -25,10 +25,13 @@ class WizardAccountFiscalPositionRule(models.TransientModel):
         return {
             "name": template.name,
             "description": template.description,
+            "from_country_group_id": template.from_country_group_id.id,
             "from_country": template.from_country.id,
             "from_state": template.from_state.id,
+            "to_invoice_country_group_id": template.to_invoice_country_group_id.id,
             "to_invoice_country": template.to_invoice_country.id,
             "to_invoice_state": template.to_invoice_state.id,
+            "to_shipping_country_group_id": template.to_shipping_country_group_id.id,
             "to_shipping_country": template.to_shipping_country.id,
             "to_shipping_state": template.to_shipping_state.id,
             "company_id": company_id,

--- a/setup/account_fiscal_position_rule/.eggs/README.txt
+++ b/setup/account_fiscal_position_rule/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+


### PR DESCRIPTION
This PR allows to select a country group in the Invoice/Shipping fields of a fiscal position rule. A rule linked to a country group will apply to all countries of the group. 

Based on https://github.com/OCA/account-fiscal-rule/pull/100