### PR TITLE
12.0 FIX prd_classif: set taxes on all companies sharing classif

### DIFF
--- a/account_product_fiscal_classification/__manifest__.py
+++ b/account_product_fiscal_classification/__manifest__.py
@@ -25,6 +25,7 @@
         'views/view_account_product_fiscal_classification_template.xml',
     ],
     'demo': [
+        'demo/res_company.xml',
         'demo/account_tax.xml',
         'demo/account_product_fiscal_classification.xml',
         'demo/product_template.xml',

--- a/account_product_fiscal_classification/demo/account_product_fiscal_classification.xml
+++ b/account_product_fiscal_classification/demo/account_product_fiscal_classification.xml
@@ -27,6 +27,18 @@
         <field name="purchase_tax_ids" eval="[(6, 0, [ref('account_tax_purchase_1')])]"/>
     </record>
     <record model="account.product.fiscal.classification" id="global_fiscal_classification_1">
+        <field name="name">Demo Global Fiscal Classification 1</field>
+        <field name="company_id" eval="0"/>
+        <field name="purchase_tax_ids" eval="[(6, 0, [ref('account_tax_purchase_1'), ref('purchase_tax_44_other')])]"/>
+        <field name="sale_tax_ids" eval="[(6, 0, [ref('account_tax_sale_1'), ref('sale_tax_44_other')])]"/>
+    </record>
+    <record model="account.product.fiscal.classification" id="global_fiscal_classification_2">
+        <field name="name">Demo Global Fiscal Classification 2</field>
+        <field name="company_id" eval="0"/>
+        <field name="purchase_tax_ids" eval="[(6, 0, [ref('account_tax_purchase_1'), ref('purchase_tax_7_other')])]"/>
+        <field name="sale_tax_ids" eval="[(6, 0, [ref('account_tax_sale_2'), ref('sale_tax_7_other')])]"/>
+    </record>
+    <record model="account.product.fiscal.classification" id="global_fiscal_classification_1">
         <field name="company_id" eval="False"/>
         <field name="name">Demo Global Fiscal Classification 1</field>
     </record>

--- a/account_product_fiscal_classification/demo/account_tax.xml
+++ b/account_product_fiscal_classification/demo/account_tax.xml
@@ -7,6 +7,7 @@
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
+
     <record model="account.tax" id="account_tax_purchase_1">
         <field name="name">Demo Purchase Tax 10%</field>
         <field name="company_id" ref="base.main_company"/>
@@ -25,4 +26,38 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">0.03</field>
     </record>
+
+    <!-- Alternate company -->
+    <record id="sale_tax_7_other" model="account.tax">
+        <field name="name">Demo 7 %</field>
+        <field name="amount">7</field>
+        <field name="type_tax_use">sale</field>
+        <field name="company_id" ref="cpny_onlyshare_classification"/>
+        <field name="tax_group_id" ref="account.tax_group_taxes"/>
+    </record>
+
+    <record id="sale_tax_44_other" model="account.tax">
+        <field name="name">Demo 44 %</field>
+        <field name="amount">44</field>
+        <field name="type_tax_use">sale</field>
+        <field name="company_id" ref="cpny_onlyshare_classification"/>
+        <field name="tax_group_id" ref="account.tax_group_taxes"/>
+    </record>
+
+    <record id="purchase_tax_7_other" model="account.tax">
+        <field name="name">Demo 7 % purch</field>
+        <field name="amount">7</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="company_id" ref="cpny_onlyshare_classification"/>
+        <field name="tax_group_id" ref="account.tax_group_taxes"/>
+    </record>
+
+    <record id="purchase_tax_44_other" model="account.tax">
+        <field name="name">Demo 44 % purch</field>
+        <field name="amount">44</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="company_id" ref="cpny_onlyshare_classification"/>
+        <field name="tax_group_id" ref="account.tax_group_taxes"/>
+    </record>
+
 </odoo>

--- a/account_product_fiscal_classification/demo/product_template.xml
+++ b/account_product_fiscal_classification/demo/product_template.xml
@@ -7,6 +7,7 @@
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
+
     <record model="product.template" id="product_template_1">
         <field name="name">Demo Product With Fiscal Classification</field>
         <field name="company_id" ref="base.main_company"/>
@@ -18,4 +19,17 @@
         <field name="uom_id" ref="uom.product_uom_unit"/>
         <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
+
+    <record model="product.template" id="product_template_all_cpnies">
+        <field name="name">Demo Product Fiscal Classif all companies</field>
+        <field name="company_id" eval="0"/>
+        <field name="categ_id" ref="product.product_category_all"/>
+        <field name="type">service</field>
+        <field name="standard_price">27.0</field>
+        <field name="list_price">37.0</field>
+        <field name="fiscal_classification_id" ref="global_fiscal_classification_1"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+    </record>
+
 </odoo>

--- a/account_product_fiscal_classification/demo/res_company.xml
+++ b/account_product_fiscal_classification/demo/res_company.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<odoo>
+
+    <record id="cpny_onlyshare_classification" model="res.company">
+        <field name="name">Other Company</field>
+    </record>
+
+    <record id="base.user_admin" model="res.users">
+        <field name="company_ids" eval="[(4,ref('cpny_onlyshare_classification'))]"/>
+    </record>
+
+    <record id="base.user_demo" model="res.users">
+        <field name="company_ids" eval="[(4,ref('cpny_onlyshare_classification'))]"/>
+    </record>
+
+
+</odoo>

--- a/account_product_fiscal_classification/models/product_template.py
+++ b/account_product_fiscal_classification/models/product_template.py
@@ -106,9 +106,9 @@ class ProductTemplate(models.Model):
                 classification = template.fiscal_classification_id
                 tax_vals = {
                     'supplier_taxes_id': [[6, 0, [
-                        x.id for x in classification.purchase_tax_ids]]],
+                        x.id for x in classification.sudo().purchase_tax_ids]]],
                     'taxes_id': [[6, 0, [
-                        x.id for x in classification.sale_tax_ids]]],
+                        x.id for x in classification.sudo().sale_tax_ids]]],
                 }
                 super(ProductTemplate, template.sudo()).write(tax_vals)
             elif ('supplier_taxes_id' in vals.keys() or

--- a/account_product_fiscal_classification/readme/CONTRIBUTORS.rst
+++ b/account_product_fiscal_classification/readme/CONTRIBUTORS.rst
@@ -1,4 +1,8 @@
-* Sylvain LE GAL (https://twitter.com/legalsylvain);
-* Sébastien BEAU <sebastien.beau@akretion.com>;
-* Danimar RIBEIRO;
-* Pierrick Brun <pierrick.brun@akretion.com>
+* Sylvain LE GAL (https://twitter.com/legalsylvain)
+* Akretion
+
+    * Sébastien BEAU <sebastien.beau@akretion.com>
+    * Pierrick Brun <pierrick.brun@akretion.com>
+    * Renato Lima <renato.lima@akretion.com>
+
+* Danimar RIBEIRO

--- a/account_product_fiscal_classification_test/tests/test_multicompany.py
+++ b/account_product_fiscal_classification_test/tests/test_multicompany.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class MulticompanyTests(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_classif_in_multicompany(self):
+        prd = self.env.ref(
+            "account_product_fiscal_classification.product_template_all_cpnies"
+        )
+        self.env.user.write({"company_id": self.env.ref("base.main_company").id})
+        classif1 = self.env.ref(
+            "account_product_fiscal_classification.global_fiscal_classification_1"
+        )
+        classif2 = self.env.ref(
+            "account_product_fiscal_classification.global_fiscal_classification_2"
+        )
+
+        def check_sale_purchase_tax(classif, write_classif=True):
+            if write_classif:
+                prd.write({"fiscal_classification_id": classif.id})
+            self.assertEqual(prd.sudo().taxes_id, classif.sudo().sale_tax_ids)
+            self.assertEqual(
+                prd.sudo().supplier_taxes_id, classif.sudo().purchase_tax_ids
+            )
+
+        # test write with 2 classifications on the same company
+        check_sale_purchase_tax(classif1)
+        check_sale_purchase_tax(classif2)
+        # test the same data but from another company point of view
+        self.env.user.write(
+            {
+                "company_id": self.env.ref(
+                    "account_product_fiscal_classification."
+                    "cpny_onlyshare_classification"
+                ).id
+            }
+        )
+        # check with same data
+        check_sale_purchase_tax(classif2, write_classif=False)
+        check_sale_purchase_tax(classif1)


### PR DESCRIPTION
Missing sudo prevent to see all taxes in other companies and lead to write bad values in product tax fields

Bug appears only when no parent_id in your companies

cc @legalsylvain @PierrickBrun 