### PR TITLE
[FIX] account_avatax: Credit Notes were being sent as positive amounts to Avatax service

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -128,7 +128,7 @@ class AccountMove(models.Model):
         Prepare the lines to use for Avatax computation.
         Returns a list of dicts
         """
-        sign = self.type == "out_invoice" and 1 or -1
+        sign = 1 if self.type.startswith("out") else -1
         lines = [
             line._avatax_prepare_line(sign, doc_type)
             for line in self.invoice_line_ids


### PR DESCRIPTION
The "sign" is supposed to be +1 for outgoing docs and -1 for incoming docs.
An "out_refund" is still an +1 outgoing doc, like "out_invoice".