### PR TITLE
[FIX] account_avatax: use for destination address the ship-to comped field, honoring the Tax on Shippling Address flag

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -151,7 +151,7 @@ class AccountMove(models.Model):
             doc_type,
             self.partner_id,
             self.warehouse_id.partner_id or self.company_id.partner_id,
-            self.partner_shipping_id or self.partner_id,
+            self.shipping_add_id or self.partner_id,
             taxable_lines,
             self.user_id,
             self.exemption_code or None,

--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -47,8 +47,8 @@ class AccountMove(models.Model):
     tax_on_shipping_address = fields.Boolean(
         "Tax based on shipping address", default=True
     )
-    shipping_add_id = fields.Many2one(
-        "res.partner", "Tax Shipping Address", compute="_compute_shipping_add_id"
+    tax_address_id = fields.Many2one(
+        "res.partner", "Tax Shipping Address", compute="_compute_tax_address_id"
     )
     location_code = fields.Char(
         "Location Code", readonly=True, states={"draft": [("readonly", False)]}
@@ -76,15 +76,15 @@ class AccountMove(models.Model):
                 inv.amount_total_signed = inv.amount_total * sign
 
     @api.depends("tax_on_shipping_address", "partner_id", "partner_shipping_id")
-    def _compute_shipping_add_id(self):
+    def _compute_tax_address_id(self):
         for invoice in self:
-            invoice.shipping_add_id = (
+            invoice.tax_address_id = (
                 invoice.partner_shipping_id
                 if invoice.tax_on_shipping_address
                 else invoice.partner_id
             )
 
-    @api.onchange("shipping_add_id", "fiscal_position_id")
+    @api.onchange("tax_address_id", "fiscal_position_id")
     def onchange_reset_avatax_amount(self):
         """
         When changing quantities or prices, reset the Avatax computed amount.
@@ -151,7 +151,7 @@ class AccountMove(models.Model):
             doc_type,
             self.partner_id,
             self.warehouse_id.partner_id or self.company_id.partner_id,
-            self.shipping_add_id or self.partner_id,
+            self.tax_address_id or self.partner_id,
             taxable_lines,
             self.user_id,
             self.exemption_code or None,
@@ -262,7 +262,7 @@ class AccountMove(models.Model):
                 "location_code": self.location_code,
                 "exemption_code": self.exemption_code or "",
                 "exemption_code_id": self.exemption_code_id.id or None,
-                "shipping_add_id": self.shipping_add_id.id,
+                "tax_address_id": self.tax_address_id.id,
             }
         )
         return move_vals

--- a/account_avatax/views/account_move_view.xml
+++ b/account_avatax/views/account_move_view.xml
@@ -22,7 +22,7 @@
                     options="{'no_create': True}"
                     groups="stock.group_stock_multi_warehouses"
                 />
-                <field name="shipping_add_id" />
+                <field name="tax_address_id" />
                 <field name="exemption_locked" />
             </field>
         </field>

--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -114,7 +114,7 @@ class SaleOrder(models.Model):
             doc_type,
             self.partner_id,
             self.warehouse_id.partner_id or self.company_id.partner_id,
-            self.partner_shipping_id or self.partner_id,
+            self.tax_address_id or self.partner_id,
             taxable_lines,
             self.user_id,
             self.exemption_code or None,


### PR DESCRIPTION
The destination address should be taken from the computed field for that, not directly from the shiping-to address.
This was correct in v12, and the error introduced in the v13 port.

The expected behavior is, when the "Tax on Shipping Address" is unchecked, then the destination address should be the Customer one and not the Delivery Address.