### PR TITLE
[13.0][FIX] account_avatax_sale: AttributeError: 'sale.order' object has no attribute 'tax_add_id'

### DIFF
--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -19,7 +19,7 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).onchange_partner_shipping_id()
 
         invoice_partner = self.partner_invoice_id.commercial_partner_id
-        ship_to_address = self.tax_add_id
+        ship_to_address = self.tax_address_id
         # Find an exemption address matching the Country + State
         # of the Delivery address
         exemption_addresses = (invoice_partner | invoice_partner.child_ids).filtered(


### PR DESCRIPTION
We are using the latest code(a57934a) from 13.0 branch
We got this error, when we selected a partner in the Sales order form.

```
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 619, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 309, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 664, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 345, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/service/model.py", line 93, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 338, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 909, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/http.py", line 510, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/custdemo13-odoo/src/13.0/addons/web/controllers/main.py", line 1319, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/addons/web/controllers/main.py", line 1311, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/api.py", line 411, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/api.py", line 398, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/models.py", line 5943, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/opt/odoo/custdemo13-odoo/src/13.0/odoo/models.py", line 5744, in _onchange_eval
    method_res = method(self)
  File "/opt/odoo/custdemo13-odoo/src/community_modules/account-fiscal-rule/account_avatax_sale/models/sale_order.py", line 22, in onchange_partner_shipping_id
    ship_to_address = self.tax_add_id
AttributeError: 'sale.order' object has no attribute 'tax_add_id'

```
@dreispt 