### PR TITLE
[FIX] account_avatax: 100% discount lines should also be sent to Avatax

### DIFF
--- a/account_avatax/models/avatax_rest_api.py
+++ b/account_avatax/models/avatax_rest_api.py
@@ -239,7 +239,6 @@ class AvaTaxRESTService:
                 "taxCode": line.get("tax_code"),
             }
             for line in received_lines
-            if line.get("amount")
         ]
 
         if doc_date and type(doc_date) != str:


### PR DESCRIPTION
A Sale Order with 100% on all lines would not compute taxes, since no line would be sent to Avatax.
Ww should send all SO lines to Avatax, even if total amount is zero.