### PR TITLE
[FIX] account_fiscal_position_type : do not crash if domain is not set

### DIFF
--- a/account_fiscal_position_type/models/account_invoice.py
+++ b/account_fiscal_position_type/models/account_invoice.py
@@ -21,7 +21,7 @@ class AccountInvoice(models.Model):
     def _onchange_partner_id(self):
         AccountFiscalPosition = self.env['account.fiscal.position']
         res = super(AccountInvoice, self)._onchange_partner_id()
-        res['domain'] = res['domain'] or{}
+        res['domain'] = res.get('domain', {})
 
         # Update Domain
         domain = self._get_domain_fiscal_position_id()


### PR DESCRIPTION
minor fixes. for the time being, when we click on supplier / refund / create an error is raised, due to the lake of domain in the returned value. 

this PR fixes that bug.

CC : @quentinDupont #GRAPOCA (ligne 192)