### PR TITLE
[FIX] account_avatax_sale: Compute button visible on confirmed Sale Orders, unless Locked

### DIFF
--- a/account_avatax_sale/views/sale_order_view.xml
+++ b/account_avatax_sale/views/sale_order_view.xml
@@ -5,12 +5,12 @@
         <field name="type">form</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <button name="action_confirm" position="after">
+            <button name="action_cancel" position="before">
                 <button
                     name="avalara_compute_taxes"
                     type="object"
                     string="Compute Taxes"
-                    attrs="{'invisible': [('state', 'not in', ['draft'])]}"
+                    attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"
                 />
             </button>
             <field name="payment_term_id" position="after">


### PR DESCRIPTION
Because a confirmed So is still editable.

![image](https://user-images.githubusercontent.com/1246629/97299868-89e58180-184d-11eb-9c00-73f54e270b74.png)
