### PR TITLE
[FIX] account_avatax_sale: Field 'is_add_validate' definition not available

### DIFF
--- a/account_avatax_sale/models/account_move.py
+++ b/account_avatax_sale/models/account_move.py
@@ -14,5 +14,4 @@ class AccountMove(models.Model):
     def _onchange_partner_shipping_id(self):
         res = super(AccountMove, self)._onchange_partner_shipping_id()
         self.tax_on_shipping_address = bool(self.partner_shipping_id)
-        self.is_add_validate = bool(self.partner_shipping_id.validation_method)
         return res


### PR DESCRIPTION
Either we should remove the "is_add_validate" field from _onchange_partner_shipping_id or add this field to account.move