### PR TITLE
[FIX] account_avatax: fix erros

### DIFF
--- a/account_avatax/models/avalara_salestax.py
+++ b/account_avatax/models/avalara_salestax.py
@@ -165,6 +165,7 @@ class AvalaraSalestax(models.Model):
             self.service_url,
             self.request_timeout,
             self.logging,
+            config=self,
         )
 
     def create_transaction(

--- a/account_avatax/models/partner.py
+++ b/account_avatax/models/partner.py
@@ -155,6 +155,8 @@ class ResPartner(models.Model):
             )
             return False
         avatax_config = self.env.company.get_avatax_config_company()
+        if not avatax_config:
+            return False
         avatax_restpoint = AvaTaxRESTService(config=avatax_config)
         valid_address = avatax_restpoint.validate_rest_address(
             partner.street,


### PR DESCRIPTION
1. Do not raise warning on Address verification to avatax, if no configuration is setup in Odoo
2. Do not raise an error when logging is False at Avatax API

@dreispt 