### PR TITLE
[FIX] account_avatax, account_avatax_sale: Avatax calculation for Line with notes/section

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -173,7 +173,7 @@ class AccountMove(models.Model):
         sign = 1 if self.move_type.startswith("out") else -1
         lines = [
             line._avatax_prepare_line(sign, doc_type)
-            for line in self.invoice_line_ids
+            for line in self.invoice_line_ids.filtered(lambda l: not l.display_type)
             if line.price_subtotal or line.quantity
         ]
         return [x for x in lines if x]
@@ -229,7 +229,7 @@ class AccountMove(models.Model):
             Tax = self.env["account.tax"]
             tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
             taxes_to_set = []
-            lines = self.invoice_line_ids.filtered(lambda l: not l.display_type)
+            lines = self.invoice_line_ids
             for index, line in enumerate(lines):
                 tax_result_line = tax_result_lines.get(line.id)
                 if tax_result_line:

--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -134,7 +134,8 @@ class SaleOrder(models.Model):
         Returns a list of dicts
         """
         lines = [
-            line._avatax_prepare_line(sign=1, doc_type=doc_type) for line in order_lines
+            line._avatax_prepare_line(sign=1, doc_type=doc_type)
+            for line in order_lines.filtered(lambda line: not line.display_type)
         ]
         return [x for x in lines if x]
 


### PR DESCRIPTION
The index used in enumerate has the wrong list, so the tax is updated in the section/note available in that index.

cc: @dreispt @bodedra @b-kannan @SodexisTeam @stephankeller 