### PR TITLE
[FIX] action post method

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -274,7 +274,7 @@ class AccountMove(models.Model):
         """
         return self.is_sale_document()
 
-    def _post(self, soft=True):
+    def post(self):
         for invoice in self:
             if invoice.is_avatax_calculated():
                 avatax_config = self.company_id.get_avatax_config_company()
@@ -289,7 +289,7 @@ class AccountMove(models.Model):
                 # However, we can't save the invoice because it wasn't assigned a
                 # number yet
                 invoice.avatax_compute_taxes(commit=False)
-        res = super()._post()
+        res = super().post()
         for invoice in res:
             if invoice.is_avatax_calculated():
                 # We can only commit to Avatax after validating the invoice


### PR DESCRIPTION
PR analysis: 

- _post() method not available in v13.0
- Tried to compatible with v14.0

Before PR:
-----------

- Customer invoice stopped commits on the Avalara side.

After PR:
----------

- Customer invoice start commit on the Avalara side.

UPDATE:
------------

- Create a customer invoice and post it.
- Create a credit memo for that invoice.
- Both are posted in Avalara with PR changes.


![Screenshot_2021-05-06 AvaTax Productivity Quality, Inc Transactions](https://user-images.githubusercontent.com/14229503/117370953-fb952c80-ae7b-11eb-9130-e68bd46ce31a.png)
