### PR TITLE
[14.0][FIX] account_avatax,account_avatax_sale: avoid long field computations on module install

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
 
         For this to work properly, the "exemption_lock" is no longer supported.
         """
-        for invoice in self:
+        for invoice in self.filtered(lambda x: x.state == "draft"):
             invoice_partner = invoice.partner_id.commercial_partner_id
             ship_to_address = (
                 hasattr(invoice, "partner_shipping_id")

--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -22,7 +22,7 @@ class SaleOrder(models.Model):
 
     @api.depends("partner_invoice_id", "tax_address_id", "company_id")
     def _compute_onchange_exemption(self):
-        for order in self:
+        for order in self.filtered(lambda x: x.state not in ["done", "cancel"]):
             invoice_partner = order.partner_invoice_id.commercial_partner_id
             ship_to_address = order.tax_address_id
             # Find an exemption address matching the Country + State


### PR DESCRIPTION
When installing on a database with many Account Moves or Sales Orders, it takes too much time and is interrupted by worker time limits.