### PR TITLE
[ADD] account_avatax_website_sale

### DIFF
--- a/account_avatax_website_sale/README.rst
+++ b/account_avatax_website_sale/README.rst
@@ -1,0 +1,7 @@
+=========================================
+Avalara Avatax Connector for eCommerce
+=========================================
+
+This module is a component of the Avatax Integration with odoo app.
+Please refer to the corresponding documentation.
+

--- a/account_avatax_website_sale/__init__.py
+++ b/account_avatax_website_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/account_avatax_website_sale/__manifest__.py
+++ b/account_avatax_website_sale/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "Avalara Avatax Connector for Ecommerce",
+    "version": "14.0.1.1.0",
+    "author": "Cybernexus Solutions, Odoo Community Association (OCA)",
+    "summary": "Ecommerce Sales Orders require tax recalculation prior to payment.",
+    "license": "AGPL-3",
+    "category": "Website/Website",
+    "website": "https://github.com/OCA/account-fiscal-rule",
+    "depends": ["account_avatax", "website_sale"],
+    "data": [],
+    "auto_install": True,
+    "development_status": "Beta",
+    "maintainers": ["cybernexus"],
+}

--- a/account_avatax_website_sale/controllers/__init__.py
+++ b/account_avatax_website_sale/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/account_avatax_website_sale/controllers/main.py
+++ b/account_avatax_website_sale/controllers/main.py
@@ -1,0 +1,10 @@
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class AvataxWebsiteSale(WebsiteSale):
+    def payment(self, **post):
+        order = request.website.sale_get_order()
+        order._avatax_compute_tax()
+        return super(AvataxWebsiteSale, self).payment(**post)

--- a/account_avatax_website_sale/readme/CONTRIBUTORS.rst
+++ b/account_avatax_website_sale/readme/CONTRIBUTORS.rst
@@ -1,0 +1,20 @@
+* Odoo SA
+
+  * Fabrice Henrion
+
+* Open Source Integrators (https://opensourceintegrators.com)
+
+  * Daniel Reis <dreis@opensourceintegrators.com>
+  * Bhavesh Odedra <bodedra@opensourceintegrators.com>
+
+* Serpent CS
+
+  * Murtuza Saleh
+
+* Sodexis
+
+  * Atchuthan Ubendran
+
+* Cybernexus Solutions
+
+  * Peter Snyder

--- a/account_avatax_website_sale/readme/DESCRIPTION.rst
+++ b/account_avatax_website_sale/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module is a component of the Avatax Integration with odoo app.
+Please refer to the corresponding documentation.

--- a/account_avatax_website_sale/readme/USAGE.rst
+++ b/account_avatax_website_sale/readme/USAGE.rst
@@ -1,0 +1,1 @@
+* Adds the functionality to recalculate taxes prior to payment step during website checkout.


### PR DESCRIPTION
During an ecommerce checkout the taxes are not computed correctly (or at all) on a sales order. 

This module ensures that taxes are calculated during the checkout, specifically prior to taking payment for an order.