### PR TITLE
[FIX] account_avatax: Get username & password from config

### DIFF
--- a/account_avatax/models/avatax_rest_api.py
+++ b/account_avatax/models/avatax_rest_api.py
@@ -37,6 +37,8 @@ class AvaTaxRESTService:
         self.environment = (
             "sandbox" if "sandbox" in url or "development" in url else "production"
         )
+        username = username or (config and config.account_number) or False
+        password = password or (config and config.license_key) or False
         if username and password:
             try:
                 self.client = AvataxClient(
@@ -50,8 +52,6 @@ class AvaTaxRESTService:
                         "to 'pip3 install Avalara'"
                     )
                 )
-            username = username or config.account_number
-            password = password or config.license_key
             self.client.add_credentials(username, password)
 
     def _sanitize_text(self, text):


### PR DESCRIPTION
 if not found in the parameter set to False
https://github.com/OCA/account-fiscal-rule/pull/199 changed the way the AvaTaxRESTService __init__ is called.
cc: @dreispt @mgosai @bodedra @stephankeller @SodexisTeam 