### PR TITLE
[FIX] account_avatax_exemption_base: license must be AGPL because of dependencies

### DIFF
--- a/account_avatax_exemption_base/__manifest__.py
+++ b/account_avatax_exemption_base/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "website": "https://github.com/OCA/account-fiscal-rule",
     "author": "Sodexis, Odoo Community Association (OCA)",
-    "license": "LGPL-3",
+    "license": "AGPL-3",
     "depends": [
         "account_avatax",
         "account_avatax_sale",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1246629/121882370-5b4ae700-cd08-11eb-9115-ffc50591209c.png)
