### PR TITLE
[FIX] account_avatax: tax copy method overrides the default dict

### DIFF
--- a/account_avatax/models/account_tax.py
+++ b/account_avatax/models/account_tax.py
@@ -48,6 +48,8 @@ class AccountTax(models.Model):
                 "name": self._get_avalara_tax_name(tax_rate, doc_type),
             }
             tax = tax_template.sudo().copy(default=vals)
+            # Odoo core does not use the name set in default dict
+            tax.name = vals.get("name")
         return tax
 
     def compute_all(


### PR DESCRIPTION
PR Description:

- In v14, (https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_tax.py#L185) copy method in account/models/account_tax.py overrides the default dict passed and resets name. So, setting the name explicitly in the connector module.