### PR TITLE
[IMP] account_avatax_sale: add override line taxes option

### DIFF
--- a/account_avatax_sale/models/avalara_salestax.py
+++ b/account_avatax_sale/models/avalara_salestax.py
@@ -13,3 +13,7 @@ class AvalaraSalestax(models.Model):
         "SO's warehouse_id, tax_on_shipping_address, "
         "SO line's price_unit, discount, product_uom_qty",
     )
+    override_line_taxes = fields.Boolean(
+        help="When checked, the Avatax computed tax will replace any other taxes"
+        " that may exist in the document line.",
+    )

--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -140,7 +140,7 @@ class SaleOrder(models.Model):
         return [x for x in lines if x]
 
     def _avatax_compute_tax(self):
-        """ Contact REST API and recompute taxes for a Sale Order """
+        """Contact REST API and recompute taxes for a Sale Order"""
         self and self.ensure_one()
         doc_type = self._get_avatax_doc_type()
         Tax = self.env["account.tax"]
@@ -174,8 +174,12 @@ class SaleOrder(models.Model):
                 rate = tax_result_line["rate"]
                 tax = Tax.get_avalara_tax(rate, doc_type)
                 if tax not in line.tax_id:
-                    line_taxes = line.tax_id.filtered(lambda x: not x.is_avatax)
-                    line.tax_id = line_taxes | tax
+                    line_taxes = (
+                        tax
+                        if avatax_config.override_line_taxes
+                        else tax | line.tax_id.filtered(lambda x: not x.is_avatax)
+                    )
+                    line.tax_id = line_taxes
                 line.tax_amt = tax_result_line["tax"]
         self.tax_amount = tax_result.get("totalTax")
         return True

--- a/account_avatax_sale/views/avalara_salestax_view.xml
+++ b/account_avatax_sale/views/avalara_salestax_view.xml
@@ -6,6 +6,7 @@
         <field name="inherit_id" ref="account_avatax.view_avalara_salestax_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='disable_tax_reporting']" position="after">
+                <field name="override_line_taxes" />
                 <field name="use_partner_invoice_id" />
                 <field name="sale_calculate_tax" />
             </xpath>


### PR DESCRIPTION
Use case are eCommerce imported Sales Orders including taxes, that we want to be recomputed using Avatax.