### PR TITLE
[13.0][FIX] account_fiscal_position_autodetect_optional_vies: Fix tests

### DIFF
--- a/account_fiscal_position_autodetect_optional_vies/tests/test_account_fiscal_position_vies.py
+++ b/account_fiscal_position_autodetect_optional_vies/tests/test_account_fiscal_position_vies.py
@@ -26,7 +26,12 @@ class TestAccountFiscalPostitionVies(common.SavepointCase):
             }
         )
         cls.partner = cls.env["res.partner"].create(
-            {"name": "Mr Odoo", "vat": "VAT", "country_id": cls.env.ref("base.es").id}
+            {
+                "name": "Mr Odoo",
+                "vat": "VAT",
+                "country_id": cls.env.ref("base.es").id,
+                "company_type": "company",
+            }
         )
         cls.vatnumber_path = "odoo.addons.base_vat.models.res_partner.vatnumber"
 


### PR DESCRIPTION
Force company type in test partner

After OCA/OCB@4518968#diff-1ef5fe83935572c9b9b9e6eec69a44551023f3b92fe38bed4f765a24e16694b4 and OCA/OCB@198a4dd the associated partner needs to be of type `company` for the vies check to work.

Related to `base_vat_optional_vies`: https://github.com/OCA/account-financial-tools/pull/1279

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa