### PR TITLE
[FIX] account_avatax: Reset to Draft button fix

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -336,6 +336,7 @@ class AccountMove(models.Model):
         """
         Sets invoice to Draft, either from the Posted or Cancelled states
         """
+        res = super(AccountMove, self).button_draft()
         for invoice in self:
             if (
                 invoice.move_type in ["out_invoice", "out_refund"]
@@ -346,7 +347,7 @@ class AccountMove(models.Model):
                 if avatax_config:
                     doc_type = invoice._get_avatax_doc_type()
                     avatax_config.void_transaction(invoice.name, doc_type)
-        return super(AccountMove, self).button_draft()
+        return res
 
     @api.onchange(
         "invoice_line_ids",


### PR DESCRIPTION
To simulate this error:

1. Post an invoice and transaction will be created to Avatax.
2. Lock the entries.
3. Click on Reset to draft button, and you will receive error "You cannot add/modify entries prior to and inclusive of the lock date" in odoo, but the transaction will be moved to voided state in Avatax.

So, I have changed the code such that we check all the Odoo conditions prior to sending the Avatax API call to void the transaction to avatax.

cc: @SodexisTeam @dreispt 