### PR TITLE
[FIX]l10n_eu_oss_oca: Prevent errors in invoices when using OSS FP.

### DIFF
--- a/l10n_eu_oss_oca/__manifest__.py
+++ b/l10n_eu_oss_oca/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "L10n EU OSS OCA",
-    "version": "15.0.2.0.0",
+    "version": "15.0.2.1.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-fiscal-rule",
     "author": "Sygel Technology," "Odoo Community Association (OCA)",
@@ -11,11 +11,12 @@
     "application": False,
     "installable": True,
     "development_status": "Production/Stable",
-    "depends": ["account", "account_fiscal_position_partner_type"],
+    "depends": ["account", "account_fiscal_position_partner_type", "sale"],
     "data": [
         "security/ir.model.access.csv",
         "data/oss.tax.rate.csv",
         "wizard/l10n_eu_oss_wizard.xml",
         "views/res_config_settings.xml",
+        "views/account_fiscal_position_views.xml",
     ],
 }

--- a/l10n_eu_oss_oca/migrations/15.0.2.1.0/post-migration.py
+++ b/l10n_eu_oss_oca/migrations/15.0.2.1.0/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Sygel - Manuel Regidor
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_fiscal_position afp
+        SET oss_oca = True
+        WHERE afp.country_id IS NOT NULL AND
+        afp.vat_required IS False AND
+        afp.auto_apply IS True AND
+        afp.fiscal_position_type = 'b2c'
+        """,
+    )

--- a/l10n_eu_oss_oca/models/__init__.py
+++ b/l10n_eu_oss_oca/models/__init__.py
@@ -3,3 +3,6 @@
 
 from . import oss_tax_rate
 from . import account_tax
+from . import account_move
+from . import sale_order
+from . import account_fiscal_position

--- a/l10n_eu_oss_oca/models/account_fiscal_position.py
+++ b/l10n_eu_oss_oca/models/account_fiscal_position.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = "account.fiscal.position"
+
+    oss_oca = fields.Boolean(
+        string="OSS OCA"
+    )

--- a/l10n_eu_oss_oca/models/account_move.py
+++ b/l10n_eu_oss_oca/models/account_move.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.depends('company_id.account_fiscal_country_id', 'fiscal_position_id.country_id', 'fiscal_position_id.foreign_vat')
+    def _compute_tax_country_id(self):
+        oss_account_move_ids = self.filtered(
+            lambda a: a.fiscal_position_id and a.fiscal_position_id.oss_oca
+        )
+        for record in oss_account_move_ids:
+            record.tax_country_id = record.fiscal_position_id.country_id
+        super(AccountMove, self-oss_account_move_ids)._compute_tax_country_id()

--- a/l10n_eu_oss_oca/models/sale_order.py
+++ b/l10n_eu_oss_oca/models/sale_order.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.depends('company_id.account_fiscal_country_id', 'fiscal_position_id.country_id', 'fiscal_position_id.foreign_vat')
+    def _compute_tax_country_id(self):
+
+        oss_sale_order_ids = self.filtered(
+            lambda a: a.fiscal_position_id and a.fiscal_position_id.oss_oca
+        )
+        for record in oss_sale_order_ids:
+            record.tax_country_id = record.fiscal_position_id.country_id
+        super(SaleOrder, self-oss_sale_order_ids)._compute_tax_country_id()

--- a/l10n_eu_oss_oca/views/account_fiscal_position_views.xml
+++ b/l10n_eu_oss_oca/views/account_fiscal_position_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="view_account_position_form_l10n_eu_oss_oca" model="ir.ui.view">
+        <field name="name">view.account.position.form.l10n.eu.oss.oca</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_form" />
+        <field name="arch" type="xml">
+            <field name="country_id" position="after">
+                <field name="oss_oca" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
+++ b/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
@@ -156,6 +156,7 @@ class L10nEuOssWizard(models.TransientModel):
             "country_id": country.id,
             "fiscal_position_type": "b2c",
             "tax_ids": [(0, 0, tax_data) for tax_data in taxes_data],
+            "oss_oca": True,
         }
 
     def update_fpos(self, fpos_id, taxes_data):
@@ -222,6 +223,7 @@ class L10nEuOssWizard(models.TransientModel):
                     ("auto_apply", "=", True),
                     ("company_id", "=", self.company_id.id),
                     ("fiscal_position_type", "=", "b2c"),
+                    ("oss_oca", "=", True),
                 ]
             )
             if not fpos:


### PR DESCRIPTION
New field tax_country_id in model account.move forces using taxes related to the country set in the fiscal position (in case one has been set). Since OSS fiscal positions have a country set, it is necessary to establish that country as the invoice country, so an error does not occurr when the company does not have a VAT number to operate in that country.