### PR TITLE
[FIX]l10n_eu_oss_oca: Prevent errors when creating invoices using OSS FP

### DIFF
--- a/l10n_eu_oss_oca/__manifest__.py
+++ b/l10n_eu_oss_oca/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "L10n EU OSS OCA",
-    "version": "15.0.2.0.0",
+    "version": "15.0.2.1.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-fiscal-rule",
     "author": "Sygel Technology," "Odoo Community Association (OCA)",
@@ -17,5 +17,6 @@
         "data/oss.tax.rate.csv",
         "wizard/l10n_eu_oss_wizard.xml",
         "views/res_config_settings.xml",
+        "views/account_fiscal_position_views.xml",
     ],
 }

--- a/l10n_eu_oss_oca/migrations/15.0.2.1.0/post-migration.py
+++ b/l10n_eu_oss_oca/migrations/15.0.2.1.0/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Sygel - Manuel Regidor
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_fiscal_position afp
+        SET oss_oca = True
+        WHERE afp.country_id IS NOT NULL AND
+        afp.vat_required IS False AND
+        afp.auto_apply IS True AND
+        afp.fiscal_position_type = 'b2c'
+        """,
+    )

--- a/l10n_eu_oss_oca/models/__init__.py
+++ b/l10n_eu_oss_oca/models/__init__.py
@@ -3,3 +3,5 @@
 
 from . import oss_tax_rate
 from . import account_tax
+from . import account_move
+from . import account_fiscal_position

--- a/l10n_eu_oss_oca/models/account_fiscal_position.py
+++ b/l10n_eu_oss_oca/models/account_fiscal_position.py
@@ -1,0 +1,10 @@
+# Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = "account.fiscal.position"
+
+    oss_oca = fields.Boolean(string="OSS OCA")

--- a/l10n_eu_oss_oca/models/account_move.py
+++ b/l10n_eu_oss_oca/models/account_move.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.depends(
+        "company_id.account_fiscal_country_id",
+        "fiscal_position_id.country_id",
+        "fiscal_position_id.foreign_vat",
+    )
+    def _compute_tax_country_id(self):
+        oss_account_move_ids = self.filtered(
+            lambda a: a.fiscal_position_id and a.fiscal_position_id.oss_oca
+        )
+        for record in oss_account_move_ids:
+            record.tax_country_id = record.fiscal_position_id.country_id
+        return super(AccountMove, self - oss_account_move_ids)._compute_tax_country_id()

--- a/l10n_eu_oss_oca/views/account_fiscal_position_views.xml
+++ b/l10n_eu_oss_oca/views/account_fiscal_position_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Manuel Regidor <manuel.regidor@sygel.es>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="view_account_position_form_l10n_eu_oss_oca" model="ir.ui.view">
+        <field name="name">view.account.position.form.l10n.eu.oss.oca</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_form" />
+        <field name="arch" type="xml">
+            <field name="country_id" position="after">
+                <field name="oss_oca" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
+++ b/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
@@ -156,6 +156,7 @@ class L10nEuOssWizard(models.TransientModel):
             "country_id": country.id,
             "fiscal_position_type": "b2c",
             "tax_ids": [(0, 0, tax_data) for tax_data in taxes_data],
+            "oss_oca": True,
         }
 
     def update_fpos(self, fpos_id, taxes_data):
@@ -222,6 +223,7 @@ class L10nEuOssWizard(models.TransientModel):
                     ("auto_apply", "=", True),
                     ("company_id", "=", self.company_id.id),
                     ("fiscal_position_type", "=", "b2c"),
+                    ("oss_oca", "=", True),
                 ]
             )
             if not fpos:


### PR DESCRIPTION
Steps to reproduce the error:

1. A new invoice is created and an OSS Fiscal Postion is set (e.g. 'Intra-EU B2C in France (EU-OSS-FR)')
![l10n_eu_oss_oca_1](https://user-images.githubusercontent.com/62256279/150819831-6abfedb4-d5be-4df3-878e-0aae52a55928.png)
2. When creating a new line, the right tax is set on the invoice line.
![l10n_eu_oss_oca_2](https://user-images.githubusercontent.com/62256279/150819944-50e1754b-7a3b-4bf3-a774-e65fd7db13df.png)
3. If we try to save the invoice, an error occurs that indicates that we are trying to use taxes from an unallowed country
![l10n_eu_oss_oca_3](https://user-images.githubusercontent.com/62256279/150821495-c1e5e416-93b8-43ec-a0b5-3f9975406b50.png)

That happens because there is a new computed field named tax_country_id in model account.move that retricts which taxes can be used depending on the country. In the example, because the Fiscal Postion 'Intra-EU B2C in France (EU-OSS-FR)' has France set as the country, if we do not have a VAT number established in that Fiscal Position in field foreign_vat, the  field tax_country_id in the invoice is not set to France so we cannot use a tax that is applicable to France.

The proposed solution adds a field to the fiscal position model to indicate whether a fiscal position belongs to the OSS system. This field is considered when the field tax_country_id in invoices is calculated, so the country established in the invoice is the one set in the fiscal position.
