### PR TITLE
[15.0][FW][FIX] account_avatax: Void transaction from posted status

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -342,17 +342,17 @@ class AccountMove(models.Model):
         """
         Sets invoice to Draft, either from the Posted or Cancelled states
         """
+        posted_invoices = self.filtered(
+            lambda invoice: invoice.move_type in ["out_invoice", "out_refund"]
+            and invoice.fiscal_position_id.is_avatax
+            and invoice.state == "posted"
+        )
         res = super(AccountMove, self).button_draft()
-        for invoice in self:
-            if (
-                invoice.move_type in ["out_invoice", "out_refund"]
-                and self.fiscal_position_id.is_avatax
-                and invoice.state == "posted"
-            ):
-                avatax_config = self.company_id.get_avatax_config_company()
-                if avatax_config:
-                    doc_type = invoice._get_avatax_doc_type()
-                    avatax_config.void_transaction(invoice.name, doc_type)
+        for invoice in posted_invoices:
+            avatax_config = invoice.company_id.get_avatax_config_company()
+            if avatax_config:
+                doc_type = invoice._get_avatax_doc_type()
+                avatax_config.void_transaction(invoice.name, doc_type)
         return res
 
     @api.onchange(


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-fiscal-rule/pull/265
