### PR TITLE
[FIX] account_product_fiscal_classification: order by fiscal classification by name

### DIFF
--- a/account_product_fiscal_classification/models/account_product_fiscal_classification.py
+++ b/account_product_fiscal_classification/models/account_product_fiscal_classification.py
@@ -9,6 +9,7 @@ from odoo.exceptions import ValidationError
 class AccountProductFiscalClassification(models.Model):
     _name = 'account.product.fiscal.classification'
     _description = 'Fiscal Classification'
+    _order = "name"
 
     # Default Section
     def _default_company_id(self):


### PR DESCRIPTION
trivial patch. order by name, and not by id.

CC : @rvalyi.

GRAP-403