### PR TITLE
[IMP][14.0][account_avatax] Add Hide Exemption & Tax Based on shipping address option

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -118,6 +118,21 @@ class AccountMove(models.Model):
         help="The Odoo tax will be uploaded to Avatax",
     )
 
+    @api.model
+    @api.depends("company_id")
+    def _compute_hide_exemption(self):
+        avatax_config = self.env.company.get_avatax_config_company()
+        for inv in self:
+            inv.hide_exemption = avatax_config.hide_exemption
+
+    hide_exemption = fields.Boolean(
+        "Hide Exemption & Tax Based on shipping address",
+        compute=_compute_hide_exemption,  # For past transactions visibility
+        default=lambda self: self.env.company.get_avatax_config_company,
+        help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
+        "Also, it will show Tax based on shipping address button",
+    )
+
     @api.depends(
         "line_ids.debit",
         "line_ids.credit",

--- a/account_avatax/models/avalara_salestax.py
+++ b/account_avatax/models/avalara_salestax.py
@@ -142,8 +142,15 @@ class AvalaraSalestax(models.Model):
     )
     use_so_partner_id = fields.Boolean(
         string="Use Sale Customer Code on Invoice",
-        help="If Boolean is checked, SO Partner Customer Code "
-        "on Invoice will be used",
+        help="Use Sales Order's Customer field to determine Taxable "
+        "Status on the Customer Invoice. If no Sales Order exists, "
+        "Customer field on the invoice form view will be used instead",
+    )
+    hide_exemption = fields.Boolean(
+        "Hide Exemption & Tax Based on shipping address",
+        default=False,
+        help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
+        "Also, it will show Tax based on shipping address button",
     )
     # TODO: add option to Display Prices with Tax Included
 

--- a/account_avatax/readme/CONFIGURE.rst
+++ b/account_avatax/readme/CONFIGURE.rst
@@ -35,6 +35,9 @@ Other Avatax API advanced configurations:
   - Enable UPC Taxability -- this will transmit Odoo's product ean13 number
     instead of its Internal Reference. If there is no ean13
     then the Internal Reference will be sent automatically.
+  - Hide Exemption & Tax Based on shipping address -- this will give user ability
+    to hide or show Tax Exemption and Tax Based on shipping address fields
+    at the invoice level.
 
 - Countries
 

--- a/account_avatax/readme/CONTRIBUTORS.rst
+++ b/account_avatax/readme/CONTRIBUTORS.rst
@@ -6,6 +6,7 @@
 
   * Daniel Reis <dreis@opensourceintegrators.com>
   * Bhavesh Odedra <bodedra@opensourceintegrators.com>
+  * Sandip Mangukiya <smangukiya@opensourceintegrators.com>
 
 * Serpent CS
 

--- a/account_avatax/views/account_move_view.xml
+++ b/account_avatax/views/account_move_view.xml
@@ -15,10 +15,22 @@
                 />
             </button>
             <group id="header_right_group" position="inside">
-                <field name="exemption_code" readonly="1" />
-                <field name="exemption_code_id" readonly="1" />
+                <field name="hide_exemption" invisible="1" />
+                <field
+                    name="exemption_code"
+                    readonly="1"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
+                <field
+                    name="exemption_code_id"
+                    readonly="1"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
                 <field name="location_code" />
-                <field name="tax_on_shipping_address" />
+                <field
+                    name="tax_on_shipping_address"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
             </group>
             <field name="invoice_incoterm_id" position="before">
                 <field

--- a/account_avatax/views/avalara_salestax_view.xml
+++ b/account_avatax/views/avalara_salestax_view.xml
@@ -52,7 +52,11 @@
                                 <field name="disable_tax_reporting" />
                                 <field name="upc_enable" />
                                 <field name="invoice_calculate_tax" />
-                                <field name="use_so_partner_id" />
+                                <field
+                                    name="use_so_partner_id"
+                                    groups="base.group_no_one"
+                                />
+                                <field name="hide_exemption" />
                             </group>
                         </page>
                         <page


### PR DESCRIPTION
NOTE: These changes are helpful to simplify Tax Exemption features where customer is pre-configured with Tax Exemption in Avatax account.

1. Improvements to support default use of Sale Order's Invoice Address 
2. Use Sale Customer Code on Invoice: Make this field visible into developer mode only, because there will be only exception case were Avatax will refer to Sale order's customer field instead of Invoice Address field.
3. Provide Feature: 
> Hide Exemption & Tax Based on shipping address -- this will give user ability to hide or show Tax Exemption and Tax Based on shipping address fields at the invoice level. 