### PR TITLE
[IMP][14.0][account_avatax_sale]Add hide Exemption & Tax based on shipping address feature to sale

### DIFF
--- a/account_avatax_sale/models/avalara_salestax.py
+++ b/account_avatax_sale/models/avalara_salestax.py
@@ -6,6 +6,8 @@ class AvalaraSalestax(models.Model):
 
     use_partner_invoice_id = fields.Boolean(
         "Use Invoice partner's customer code in SO",
+        default=True,
+        help="Use Sales Order's Invoice Address field to determine Taxable" "Status",
     )
     sale_calculate_tax = fields.Boolean(
         "Auto Calculate Tax on SO Save",

--- a/account_avatax_sale/models/sale_order.py
+++ b/account_avatax_sale/models/sale_order.py
@@ -4,6 +4,20 @@ from odoo import api, fields, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    @api.model
+    @api.depends("company_id", "partner_id", "partner_invoice_id", "state")
+    def _compute_hide_exemption(self):
+        avatax_config = self.env.company.get_avatax_config_company()
+        for order in self:
+            order.hide_exemption = avatax_config.hide_exemption
+
+    hide_exemption = fields.Boolean(
+        "Hide Exemption & Tax Based on shipping address",
+        compute=_compute_hide_exemption,  # For past transactions visibility
+        default=lambda self: self.env.company.get_avatax_config_company,
+        help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
+        "Also, it will show Tax based on shipping address button",
+    )
     tax_amount = fields.Monetary(string="AvaTax")
 
     @api.onchange("partner_shipping_id", "partner_id")

--- a/account_avatax_sale/readme/CONTRIBUTORS.rst
+++ b/account_avatax_sale/readme/CONTRIBUTORS.rst
@@ -6,6 +6,7 @@
 
   * Daniel Reis <dreis@opensourceintegrators.com>
   * Bhavesh Odedra <bodedra@opensourceintegrators.com>
+  * Sandip Mangukiya <smangukiya@opensourceintegrators.com>
 
 * Serpent CS
 

--- a/account_avatax_sale/readme/USAGE.rst
+++ b/account_avatax_sale/readme/USAGE.rst
@@ -28,6 +28,9 @@ Compute Taxes with AvaTax
   Location code will automatically populate with the warehouse code
   but can be modified if needed.
 
+- Hide Exemption & Tax Based on shipping address -- this will provide this
+  feature support at sale order level.
+
 
 Tax Exemption Status
 

--- a/account_avatax_sale/views/sale_order_view.xml
+++ b/account_avatax_sale/views/sale_order_view.xml
@@ -14,10 +14,22 @@
                 />
             </button>
             <field name="payment_term_id" position="after">
-                <field name="exemption_code" readonly="1" />
-                <field name="exemption_code_id" readonly="1" />
+                <field name="hide_exemption" invisible="1" />
+                <field
+                    name="exemption_code"
+                    readonly="1"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
+                <field
+                    name="exemption_code_id"
+                    readonly="1"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
                 <field name="location_code" />
-                <field name="tax_on_shipping_address" />
+                <field
+                    name="tax_on_shipping_address"
+                    attrs="{'invisible': [('hide_exemption','=',True)]}"
+                />
             </field>
             <field name="fiscal_position_id" position="after">
                 <field


### PR DESCRIPTION
Depends on https://github.com/OCA/account-fiscal-rule/pull/278

Feature:
- Hide Exemption & Tax Based on shipping address -- this will provide this 
  feature support at sale order level.