### PR TITLE
[FIX][14.0] account_avatax

### DIFF
--- a/account_avatax/models/account_move.py
+++ b/account_avatax/models/account_move.py
@@ -380,7 +380,7 @@ class AccountMove(models.Model):
                     line._origin.price_unit != line.price_unit
                     or line._origin.discount != line.discount
                     or line._origin.quantity != line.quantity
-                ):
+                ) and not line.display_type:
                     self.calculate_tax_on_save = True
                     break
 


### PR DESCRIPTION
Fixed AVATAX Validation  Error while Adding Line/Section at Invoice Line.

![image](https://user-images.githubusercontent.com/94614855/165729830-c4503ffe-e7f4-4bd4-84c4-efdb9ab6a9e2.png)

**Reproduce Steps:**
1). Create Sale Order with the Non-Validate Address (Change the address of the Sales Order after Confirming the Address).
2). Now Create an Invoice for that Sale Order.
3). Now Add the Section or  Note in the Invoice it will Trigger a Validation Error.

**Desired Output:**
When we Add the Section or  Note in the Invoice we are not Doing any calculation.
