### PR TITLE
[FIX] account_avatax: Field 'salespersonCode' has an invalid length

### DIFF
--- a/account_avatax/models/avatax_rest_api.py
+++ b/account_avatax/models/avatax_rest_api.py
@@ -286,7 +286,7 @@ class AvaTaxRESTService:
             "customerCode": partner_code,
             "businessIdentificationNo": vat,
             "referenceCode": reference_code,
-            "salespersonCode": salesman_code,
+            "salespersonCode": salesman_code and salesman_code[:25] or None,
             "reportingLocationCode": location_code,
             "entityUseCode": customer_usage_type,
             "exemptionNo": exemption_no,


### PR DESCRIPTION
Field 'salespersonCode' must be between 0 and 25 characters in length

![Screen Shot 2022-06-20 at 12 32 34 PM](https://user-images.githubusercontent.com/4667326/175292152-026810b2-8ba6-4ea2-97a3-5aeefcf0e71f.png)

cc: @SodexisTeam @dreispt 