### PR TITLE
[FIX] account_product_fiscal_classification : change classification should change taxes to raise function @onchange('taxes')

### DIFF
--- a/account_product_fiscal_classification/models/__init__.py
+++ b/account_product_fiscal_classification/models/__init__.py
@@ -1,4 +1,5 @@
 from . import product_template
+from . import product_product
 from . import product_category
 from . import account_product_fiscal_classification_template
 from . import account_product_fiscal_classification

--- a/account_product_fiscal_classification/models/product_product.py
+++ b/account_product_fiscal_classification/models/product_product.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2022-Today GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    # View Section
+    @api.onchange('fiscal_classification_id')
+    def _onchange_fiscal_classification_id(self):
+        self.supplier_taxes_id = [(
+            6, 0,
+            self.fiscal_classification_id.sudo().purchase_tax_ids.ids
+        )]
+        self.taxes_id = [(
+            6, 0,
+            self.fiscal_classification_id.sudo().sale_tax_ids.ids
+        )]

--- a/account_product_fiscal_classification/models/product_template.py
+++ b/account_product_fiscal_classification/models/product_template.py
@@ -60,6 +60,17 @@ class ProductTemplate(models.Model):
                             template.categ_id.fiscal_classification_ids])))
 
     # View Section
+    @api.onchange('fiscal_classification_id')
+    def _onchange_fiscal_classification_id(self):
+        self.supplier_taxes_id = [(
+            6, 0,
+            self.fiscal_classification_id.sudo().purchase_tax_ids.ids
+        )]
+        self.taxes_id = [(
+            6, 0,
+            self.fiscal_classification_id.sudo().sale_tax_ids.ids
+        )]
+
     @api.onchange('categ_id', 'fiscal_classification_id')
     def _onchange_categ_fiscal_classification_id(self):
         if self.categ_id and self.categ_id.fiscal_restriction:


### PR DESCRIPTION
Rational : 

- if a field product / template form view is defined by @api.onchange("taxes") (or supplier taxes).
- if we change the fiscal_classification the onchange is not raised.

this trivial patch change taxes when cassification is changed.

CC : @quentinDupont 
GRAP Task : 508