### PR TITLE
[13.0][FIX] account_fiscal_position_autodetect_optional_vies: Cover children contacts

### DIFF
--- a/account_fiscal_position_autodetect_optional_vies/models/account_fiscal_position.py
+++ b/account_fiscal_position_autodetect_optional_vies/models/account_fiscal_position.py
@@ -37,7 +37,9 @@ class AccountFiscalPosition(models.Model):
         _self = self
         if partner_id:
             partner = self.env["res.partner"].browse(delivery_id or partner_id)
-            _self = self.with_context(vat_vies_required=partner.vies_passed)
+            _self = self.with_context(
+                vat_vies_required=partner.commercial_partner_id.vies_passed
+            )
         return super(AccountFiscalPosition, _self).get_fiscal_position(
             partner_id, delivery_id
         )


### PR DESCRIPTION
Steps to reproduce the problem:

- Create a partner with a proper VIES VAT.
- Create a children for that partner.
- Create a fiscal position with "Vat was VIES validated" and
  "Auto-apply" marks checked.
- Use the children partner in an invoice.

Current behavior:

The fiscal position is not selected.

Expected behavior:

The fiscal position is selected.

@Tecnativa TT38107