### PR TITLE
[15.0][FIX] account_avatax: Field 'salespersonCode' has an invalid length (FW 290)

### DIFF
--- a/account_avatax/models/avatax_rest_api.py
+++ b/account_avatax/models/avatax_rest_api.py
@@ -285,7 +285,7 @@ class AvaTaxRESTService:
             "customerCode": partner_code,
             "businessIdentificationNo": vat,
             "referenceCode": reference_code,
-            "salespersonCode": salesman_code,
+            "salespersonCode": salesman_code and salesman_code[:25] or None,
             "reportingLocationCode": location_code,
             "entityUseCode": customer_usage_type,
             "exemptionNo": exemption_no,


### PR DESCRIPTION
.