### PR TITLE
[FIX] account_avatax_exemption: Hide Exemption Code info

### DIFF
--- a/account_avatax_exemption/__manifest__.py
+++ b/account_avatax_exemption/__manifest__.py
@@ -16,6 +16,7 @@
         "account_avatax_exemption_base",
     ],
     "data": [
+        "security/security.xml",
         "security/ir.model.access.csv",
         "data/cron.xml",
         "data/queue.xml",
@@ -29,6 +30,8 @@
         "views/website_exemption_tree.xml",
         "views/website_exemption_form.xml",
         "views/partner_view.xml",
+        "views/account_move_view.xml",
+        "views/sale_view.xml",
     ],
     "external_dependencies": {"python": ["Avalara"]},
     "installable": True,

--- a/account_avatax_exemption/security/security.xml
+++ b/account_avatax_exemption/security/security.xml
@@ -1,0 +1,14 @@
+<odoo noupdate="1">
+
+    <record id="group_show_tax_exempt_exempt_number_exempt_code" model="res.groups">
+        <field name="name">Show Tax Exempt/Exemption number/Exemption code </field>
+        <field
+            name="comment"
+        >Show the Exemption fields on SO and Invoice and Contact</field>
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
+
+</odoo>

--- a/account_avatax_exemption/views/account_move_view.xml
+++ b/account_avatax_exemption/views/account_move_view.xml
@@ -1,0 +1,38 @@
+<odoo>
+
+    <record id="exemption_hide_view_move_form_inherit_1" model="ir.ui.view">
+        <field name="name">account.move.form.view.exemption.hide</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account_avatax_oca.view_move_form_inherit_1" />
+        <field name="arch" type="xml">
+            <field name='exemption_code' position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name='exemption_code_id' position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="exemption_hide_view_move_form_with_group_inherit_1">
+        <field name="name">account.move.form.view.exemption.hide_with_group</field>
+        <field name="model">account.move</field>
+        <field
+            name="inherit_id"
+            ref="account_avatax_exemption.exemption_hide_view_move_form_inherit_1"
+        />
+        <field
+            name="groups_id"
+            eval="[(4,ref('account_avatax_exemption.group_show_tax_exempt_exempt_number_exempt_code'))]"
+        />
+        <field name="arch" type="xml">
+            <field name='exemption_code' position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+            <field name='exemption_code_id' position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_avatax_exemption/views/partner_view.xml
+++ b/account_avatax_exemption/views/partner_view.xml
@@ -34,6 +34,76 @@
                     </p>
                 </div>
             </xpath>
+            <xpath
+                expr="//field[@name='property_tax_exempt']/../separator[1]"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_tax_exempt']"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_exemption_code_id']"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_exemption_number']"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//group[@name='avatax_exemption']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_partner_exempt_form_inherit1">
+        <field name="name">res.partner.field.show.with.group.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field
+            name="inherit_id"
+            ref="account_avatax_exemption.view_partner_details_form_inherit1"
+        />
+        <field
+            name="groups_id"
+            eval="[(4,ref('account_avatax_exemption.group_show_tax_exempt_exempt_number_exempt_code'))]"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='property_tax_exempt']/../separator[1]"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_tax_exempt']"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_exemption_code_id']"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath
+                expr="//page[last()]//field[@name='property_exemption_number']"
+                position="attributes"
+            >
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath expr="//group[@name='avatax_exemption']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/account_avatax_exemption/views/sale_view.xml
+++ b/account_avatax_exemption/views/sale_view.xml
@@ -1,0 +1,47 @@
+<odoo>
+
+    <record
+        id="account_avatax_sale_oca_order_form_view_editable_field"
+        model="ir.ui.view"
+    >
+        <field name="name">account_avatax_oca.oca.sale.order.form.view.editable</field>
+        <field name="model">sale.order</field>
+        <field
+            name="inherit_id"
+            ref="account_avatax_sale_oca.sale_order_update_form_view"
+        />
+        <field name="arch" type="xml">
+            <field name='exemption_code' position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name='exemption_code_id' position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record
+        model="ir.ui.view"
+        id="account_avatax_sale_oca_order_form_view_hidden_field"
+    >
+        <field name="name">account_avatax_oca.oca.sale.order.form.view.hidden</field>
+        <field name="model">sale.order</field>
+        <field
+            name="inherit_id"
+            ref="account_avatax_exemption.account_avatax_sale_oca_order_form_view_editable_field"
+        />
+        <field
+            name="groups_id"
+            eval="[(4,ref('account_avatax_exemption.group_show_tax_exempt_exempt_number_exempt_code'))]"
+        />
+        <field name="arch" type="xml">
+            <field name='exemption_code' position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+            <field name='exemption_code_id' position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add group to show the exemption code for specific users only.  As the exemption created via Odoo, and it will be added in Avatax via API, and we don't need to send this info.

cc: @SodexisTeam @dreispt 