### PR TITLE
[FIX] account_avatax: avatax_amt_line is changed…

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -541,9 +541,18 @@ class AccountMoveLine(models.Model):
         The Odoo computed tax amount will then be shown, as a reference.
         The Avatax amount will be recomputed upon document validation.
         """
+        error_message = _(
+            "You cannot change Price, Quantity, Discount on CreditNote lines."
+            "\nIf you wish to make changes, please Go to "
+            "'Other Info' tab -> uncheck the 'Use Odoo Tax' field."
+            "\n Caution: Tax will be recomputed once this option is unchecked."
+        )
         for line in self:
-            line.avatax_amt_line = 0.0
-            line.move_id.avatax_amount = 0.0
+            if not line.move_id.avatax_amt_line_override:
+                line.avatax_amt_line = 0.0
+                line.move_id.avatax_amount = 0.0
+            else:
+                raise UserError(error_message)
 
     def _get_price_total_and_subtotal(
         self,

--- a/account_avatax_oca/views/account_move_view.xml
+++ b/account_avatax_oca/views/account_move_view.xml
@@ -69,6 +69,18 @@
                     <field name="avatax_response_log" widget="ace" />
                 </page>
             </notebook>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/tree//field[@name='price_unit']"
+                position="after"
+            >
+                <field name="avatax_amt_line" invisible="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/tree//field[@name='debit']"
+                position="before"
+            >
+                <field name="avatax_amt_line" invisible="1" />
+            </xpath>
         </field>
     </record>
     <record id="invoice_form_view_editable_field" model="ir.ui.view">


### PR DESCRIPTION
… when Override is selected in CreditNote

Add a warning when user tries to modify Price, Quantity, Discount on Credit note lines for records that have 'Use Odoo Tax' option selected.

cc: @SodexisTeam @dreispt 