### PR TITLE
[14.0][FIX] account_avatax_oca: don't overwrite date on refund

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -358,7 +358,9 @@ class AccountMove(models.Model):
         move_vals.update(
             {
                 "invoice_doc_no": self.name,
-                "invoice_date": self.invoice_date,
+                "invoice_date": default_values
+                and default_values.get("invoice_date")
+                or self.invoice_date,
                 "tax_on_shipping_address": self.tax_on_shipping_address,
                 "warehouse_id": self.warehouse_id.id,
                 "location_code": self.location_code,


### PR DESCRIPTION
@ForgeFlow
previous behavior: the _reverse_move_vals function is changing the date on refunds from the selected one to the move date
current behavior: the invoice date must remain as the one assigned on the refund wizard