### PR TITLE
[FIX] account_avatax_oca: missing definition for use_commercial_entity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/account_avatax_exemption/models/avalara_salestax.py
+++ b/account_avatax_exemption/models/avalara_salestax.py
@@ -17,7 +17,6 @@ class AvalaraSalestax(models.Model):
     tax_item_export = fields.Boolean()
     exemption_export = fields.Boolean()
     exemption_rule_export = fields.Boolean()
-    use_commercial_entity = fields.Boolean(default=True)
 
     def create_transaction(
         self,

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -134,6 +134,7 @@ class AvalaraSalestax(models.Model):
         help="Allows ean13 to be reported in place of Item Reference"
         " as upc identifier.",
     )
+    use_commercial_entity = fields.Boolean()
     invoice_calculate_tax = fields.Boolean(
         "Auto Calculate Tax on Invoice Save",
         help="Automatically triggers API to calculate tax If changes made on"


### PR DESCRIPTION
Field definition missing in account_avatax_oca for https://github.com/OCA/account-fiscal-rule/blob/14.0/account_avatax_oca/models/partner.py#L74
Originally defined in https://github.com/OCA/account-fiscal-rule/blob/14.0/account_avatax_exemption/models/avalara_salestax.py#L20

```
 File "/home/odoo/src/odoo/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/odoo/models.py", line 4078, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/odoo/src/user/account-fiscal-rule/account_avatax/models/partner.py", line 74, in _compute_use_commercial_entity
    partner.use_commercial_entity = avalara_salestax.use_commercial_entity
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'avalara.salestax' object has no attribute 'use_commercial_entity'
```

cc: @SodexisTeam @dreispt 