### PR TITLE
[FIX] account_avatax_oca: run test after all modules are installed to ensure that the journals will exist

### DIFF
--- a/account_avatax_oca/tests/test_avatax.py
+++ b/account_avatax_oca/tests/test_avatax.py
@@ -2,9 +2,10 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestAvatax(common.TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
If you install `account` and `account_avatax_oca` at the same time, one of the tests will run before the required journals are created, and it will raise an error. This is because the journals are created by one of the `l10n` modules, and while installing `account` will automatically trigger installing one of them, it will only be installed after the current batch of modules are installed. This PR tags the test class with `post_install` so that it will run after all modules are installed.