### PR TITLE
[FIX] account_avatax_oca: Don't override the invoice date when reversing moves

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -345,7 +345,6 @@ class AccountMove(models.Model):
         move_vals.update(
             {
                 "invoice_doc_no": self.name,
-                "invoice_date": self.invoice_date,
                 "tax_on_shipping_address": self.tax_on_shipping_address,
                 "warehouse_id": self.warehouse_id.id,
                 "location_code": self.location_code,


### PR DESCRIPTION
There is a `_reverse_move_vals` override that, among other things, changes the invoice date when reversing an invoice. This causes a few tests to fail:

account.tests.test_account_move_date_algorithm.TestAccountMoveDateAlgorithm.test_in_invoice_reverse_date_with_lock_date account.tests.test_account_move_date_algorithm.TestAccountMoveDateAlgorithm.test_out_invoice_reverse_date_with_lock_date account.tests.test_account_move_in_invoice.TestAccountMoveInInvoiceOnchanges.test_in_invoice_create_refund account.tests.test_account_move_in_invoice.TestAccountMoveInInvoiceOnchanges.test_in_invoice_create_refund_multi_currency account.tests.test_account_move_out_invoice.TestAccountMoveOutInvoiceOnchanges.test_out_invoice_create_refund account.tests.test_account_move_out_invoice.TestAccountMoveOutInvoiceOnchanges.test_out_invoice_create_refund_multi_currency

I'm not sure why this override exists, and the comment isn't helpful (it's copied from `stock_account`). Maybe it should be removed altogether, but I'll settle for making the tests pass.