### PR TITLE
[15.0][MIG] l10n_eu_oss_oca: Set country_id for previous taxes

### DIFF
--- a/l10n_eu_oss_oca/README.rst
+++ b/l10n_eu_oss_oca/README.rst
@@ -111,6 +111,10 @@ Contributors
 
     * Pedro M. Baeza
 
+* `Planeta Huerto <https://www.planetahuerto.es>`_:
+
+  * Pere Albujer
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/l10n_eu_oss_oca/__manifest__.py
+++ b/l10n_eu_oss_oca/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "L10n EU OSS OCA",
-    "version": "15.0.2.1.1",
+    "version": "15.0.2.2.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-fiscal-rule",
     "author": "Sygel Technology," "Odoo Community Association (OCA)",

--- a/l10n_eu_oss_oca/migrations/15.0.2.2.0/post-migration.py
+++ b/l10n_eu_oss_oca/migrations/15.0.2.2.0/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Sygel - Manuel Regidor
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_tax at
+        SET country_id = at.oss_country_id
+        WHERE at.oss_country_id IS NOT NULL
+        """,
+    )

--- a/l10n_eu_oss_oca/readme/CONTRIBUTORS.rst
+++ b/l10n_eu_oss_oca/readme/CONTRIBUTORS.rst
@@ -6,3 +6,7 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
     * Pedro M. Baeza
+
+* `Planeta Huerto <https://www.planetahuerto.es>`_:
+
+  * Pere Albujer


### PR DESCRIPTION
Odoo adds country_id in account_tax in version 15.0 and if you come from previous version of Odoo country_id is set by migration of account module and set country of company. But for OSS taxes it's wrong. The correct country_id is the same as oss_country_id