### PR TITLE
[16.0][FIX] account_avatax_oca: tax calculation improvements

### DIFF
--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -170,6 +170,7 @@ class SaleOrder(models.Model):
 
     def _avatax_compute_tax(self):
         """Contact REST API and recompute taxes for a Sale Order"""
+        # Override to handle lines with split taxes (e.g. TN)
         self and self.ensure_one()
         doc_type = self._get_avatax_doc_type()
         Tax = self.env["account.tax"]
@@ -201,7 +202,14 @@ class SaleOrder(models.Model):
                 # Should we check the rate with the tax amount?
                 # tax_amount = tax_result_line["taxCalculated"]
                 # rate = round(tax_amount / line.price_subtotal * 100, 2)
-                rate = tax_result_line["rate"]
+                # rate = tax_result_line["rate"]
+                tax_calculation = 0.0
+                if tax_result_line["taxableAmount"]:
+                    tax_calculation = (
+                        tax_result_line["taxCalculated"]
+                        / tax_result_line["taxableAmount"]
+                    )
+                rate = round(tax_calculation * 100, 4)
                 tax = Tax.get_avalara_tax(rate, doc_type)
                 if tax not in line.tax_id:
                     line_taxes = (


### PR DESCRIPTION
Improvements to v16 migration

Calculates taxes properly for lines that have split taxes. E.g. in Tennessee taxes, one line for $100 may have two applicable taxes, 4% on $75 and 4.5% on $25. Odoo should consider the total tax amount for that line ($4.13) and compute the tax rate (4.125%) based on that.

Bugfixes for unbalanced entry error, changed core Odoo method to _sync_dynamic_lines to recompute journal items