### PR TITLE
[FIX][16.0] account_avatax_sale_oca (Fixes Sale Line Access Error)

### DIFF
--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -89,7 +89,7 @@ class SaleOrder(models.Model):
         """
         for order in self:
             order.tax_amount = 0
-            order.order_line.write({"tax_amt": 0})
+            order.order_line.tax_amt = 0
 
     @api.depends("order_line.price_total", "order_line.product_uom_qty", "tax_amount")
     def _compute_amounts(self):


### PR DESCRIPTION
Fixes the following error received when creating a new sale order and adding a line.
![image](https://github.com/OCA/account-fiscal-rule/assets/36892066/52b1b6a2-914a-4430-96ea-91f59a147537)
