### PR TITLE
[14.0][FIX] account_avatax_exemption: move method onchange_partner_id of model res.partner.exemption

### DIFF
--- a/account_avatax_exemption/models/exemption.py
+++ b/account_avatax_exemption/models/exemption.py
@@ -181,6 +181,17 @@ class ResPartnerExemption(models.Model):
         readonly=True,
     )
 
+    @api.onchange("partner_id")
+    def onchange_partner_id(self):
+        avalara_salestax = (
+            self.env["avalara.salestax"]
+            .sudo()
+            .search([("exemption_export", "=", True)], limit=1)
+        )
+        if avalara_salestax.use_commercial_entity:
+            self.partner_id = self.partner_id.commercial_partner_id.id
+            return {"domain": {"partner_id": [("parent_id", "=", False)]}}
+
     def search_exemption_line(self, avatax_id):
         exemption_line = (
             self.env["res.partner.exemption.line"]

--- a/account_avatax_exemption_base/models/exemption.py
+++ b/account_avatax_exemption_base/models/exemption.py
@@ -158,17 +158,6 @@ class ResPartnerExemption(models.Model):
             res.append((record.id, name))
         return res
 
-    @api.onchange("partner_id")
-    def onchange_partner_id(self):
-        avalara_salestax = (
-            self.env["avalara.salestax"]
-            .sudo()
-            .search([("exemption_export", "=", True)], limit=1)
-        )
-        if avalara_salestax.use_commercial_entity:
-            self.partner_id = self.partner_id.commercial_partner_id.id
-            return {"domain": {"partner_id": [("parent_id", "=", False)]}}
-
     @api.onchange("exemption_type", "group_of_state")
     def onchange_exemption_type(self):
         self.business_type = self.exemption_type.business_type.id


### PR DESCRIPTION
From module account_avatax_exemption_base to account_avatax_exemption.

Because account_avatax_exemption_base does not depend on account_avatax_oca where the model 'avalara.salestax' is defined. 

cc @atchuthan