### PR TITLE
[16.0][FIX] account_avatax_oca : actually trigger avatax calculation on sav…

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -385,7 +385,7 @@ class AccountMove(models.Model):
                     line._origin.price_unit != line.price_unit
                     or line._origin.discount != line.discount
                     or line._origin.quantity != line.quantity
-                ) and not line.display_type:
+                ) and line.display_type == "product":
                     self.calculate_tax_on_save = True
                     break
 


### PR DESCRIPTION
…e when invoice lines have changed

In 16.0, display_type is a required field of the account.move.line model, so `not line.display_type` is always False

We could just remove the test on display_line, but I think the only case where price_unit, discount and quantity is relevant is for lines where display_type is "product".

Feel free to correct me if I'm wrong.

In 15.0, display_type definition is here :

https://github.com/odoo/odoo/blob/5033bc5018272c6e88b09de7b7e8565ff7344b01/addons/account/models/account_move.py#L3856-L3859

```python
    display_type = fields.Selection([
        ('line_section', 'Section'),
        ('line_note', 'Note'),
    ], default=False, help="Technical field for UX purpose.")

```
In 16.0, the same field is defined here :

https://github.com/odoo/odoo/blob/1b4894beb2ffc167dfb083d18528fa6cb065a7b9/addons/account/models/account_move_line.py#L281-L294

```python
    display_type = fields.Selection(
        selection=[
            ('product', 'Product'),
            ('cogs', 'Cost of Goods Sold'),
            ('tax', 'Tax'),
            ('rounding', "Rounding"),
            ('payment_term', 'Payment Term'),
            ('line_section', 'Section'),
            ('line_note', 'Note'),
            ('epd', 'Early Payment Discount')
        ],
        compute='_compute_display_type', store=True, readonly=False, precompute=True,
        required=True,
    )

```

