### PR TITLE
[16.0][FIX] account_avatax_oca: changed colspan

### DIFF
--- a/account_avatax_oca/views/product_view.xml
+++ b/account_avatax_oca/views/product_view.xml
@@ -56,8 +56,9 @@
                 </page>
             </xpath>
             <xpath expr="//page[1]/group" position="after">
-                <group colspan="2" col="2" string="Product Description">
+                <group col="2" string="Product Description">
                     <field
+                        colspan="2"
                         name="description"
                         placeholder="describe the product characteristics..."
                         nolabel="1"


### PR DESCRIPTION
There was an error in the product view, making the field product description looks like this:

![17043625262976272](https://github.com/OCA/account-fiscal-rule/assets/148051804/63e5d924-cb14-4960-926c-fc92e0218a4c)
