### PR TITLE
[14.0][FIX] l10n_eu_oss: Luxembourg VAT rate changed from 17% to 16%

### DIFF
--- a/l10n_eu_oss/data/oss.tax.rate.csv
+++ b/l10n_eu_oss/data/oss.tax.rate.csv
@@ -16,7 +16,7 @@ oss_eu_rate_ie,base.ie,23,13.5,9,4.8
 oss_eu_rate_it,base.it,22,10,5,4
 oss_eu_rate_lv,base.lv,21,12,5,0
 oss_eu_rate_lt,base.lt,21,9,5,0
-oss_eu_rate_lu,base.lu,17,14,8,3
+oss_eu_rate_lu,base.lu,16,13,7,3
 oss_eu_rate_mt,base.mt,18,7,5,0
 oss_eu_rate_nl,base.nl,21,9,0,0
 oss_eu_rate_pl,base.pl,23,8,5,0


### PR DESCRIPTION
Closes #365 (for 14.0)