### PR TITLE
[FIX] account_product_fiscal_classification : remove default taxes

### DIFF
--- a/account_product_fiscal_classification/models/product_template.py
+++ b/account_product_fiscal_classification/models/product_template.py
@@ -14,6 +14,10 @@ from odoo.exceptions import ValidationError
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    taxes_id = fields.Many2many(default=False)
+
+    supplier_taxes_id = fields.Many2many(default=False)
+
     fiscal_classification_id = fields.Many2one(
         comodel_name="account.product.fiscal.classification",
         string="Fiscal Classification",


### PR DESCRIPTION
When the module is installed, having default taxes has no sense. It also generate error when mass importing, if the default values doesn't match with a fiscal classification. As a result, in a demo database, installing a module that create a product when account_product_fiscal_classification is installed will fail