### PR TITLE
[17.0][FIX] account_avatax_oca: Install on multi-country

### DIFF
--- a/account_avatax_oca/data/avalara_salestax_data.xml
+++ b/account_avatax_oca/data/avalara_salestax_data.xml
@@ -7,6 +7,7 @@
     </record>
     <record id="avatax_tax_group" model="account.tax.group">
         <field name="name">AvaTax</field>
+        <field name="country_id" ref="base.us" />
     </record>
     <!-- Used as template for automatic Tax records created -->
     <record id="avatax" model="account.tax">


### PR DESCRIPTION
On install of account_avatax_oca in an environment where the main company is not in the United States, install fails with error "The tax group must have the same country_id as the tax using it.". The default tax is created in the main company, and the country_id is defined in the XML data file, but the tax group computes its country_id from the main company's country, and the SQL constraint error appears. This is true even if the active company is a USA company, and the main company is not active.