### PR TITLE
[FIX] account_fiscal_position_type: prevent error in demo / test mode, if l10n_generic_coa is not installed

### DIFF
--- a/account_fiscal_position_type/__manifest__.py
+++ b/account_fiscal_position_type/__manifest__.py
@@ -21,6 +21,7 @@
     ],
     'demo': [
         'demo/res_groups.xml',
+        'demo/account_chart_template.xml',
         'demo/account_fiscal_position.xml',
         'demo/account_fiscal_position_template.xml',
     ],

--- a/account_fiscal_position_type/demo/account_chart_template.xml
+++ b/account_fiscal_position_type/demo/account_chart_template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2022-Today GRAP (http://www.grap.coop)
+    @author Sylvain LE GAL (https://twitter.com/legalsylvain)
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ -->
+<!--  oca-hooks: disable=xml-duplicate-record-id  -->
+<odoo>
+
+    <record id="chart_template" model="account.chart.template">
+        <field name="name">Demo Chart Template (account_fiscal_position_type)</field>
+        <field name="bank_account_code_prefix">1014</field>
+        <field name="cash_account_code_prefix">1015</field>
+        <field name="transfer_account_code_prefix">1017</field>
+        <field name="currency_id" ref="base.USD"/>
+    </record>
+
+</odoo>

--- a/account_fiscal_position_type/demo/account_fiscal_position_template.xml
+++ b/account_fiscal_position_type/demo/account_fiscal_position_template.xml
@@ -4,13 +4,13 @@
         <record id="fiscal_position_template_purchase" model="account.fiscal.position.template">
             <field name="name">Fiscal Position Template (Purchase Use)</field>
             <field name="type_position_use">purchase</field>
-            <field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template" />
+            <field name="chart_template_id" ref="chart_template" />
         </record>
 
         <record id="fiscal_position_template_sale" model="account.fiscal.position.template">
             <field name="name">Fiscal Position Template (Sale Use)</field>
             <field name="type_position_use">sale</field>
-            <field name="chart_template_id" ref="l10n_generic_coa.configurable_chart_template" />
+            <field name="chart_template_id" ref="chart_template" />
         </record>
 
 </odoo>

--- a/account_fiscal_position_type/tests/test_module.py
+++ b/account_fiscal_position_type/tests/test_module.py
@@ -16,7 +16,7 @@ class Tests(TransactionCase):
         self.AccountFiscalPosition = self.env['account.fiscal.position']
         self.company = self.env.ref('base.main_company')
         self.chart_template = self.env.ref(
-            'l10n_generic_coa.configurable_chart_template')
+            'account_fiscal_position_type.chart_template')
         self.fiscal_position_template_purchase = self.env.ref(
             'account_fiscal_position_type.fiscal_position_template_purchase')
         self.fiscal_position_purchase = self.env.ref(


### PR DESCRIPTION
**rational**

demo and test are based on l10n_generic_coa data. However, if other localization are installed, the installation of this module will fail with demo data.

**Action**
create a dedicated demo chart of account.

similar to v16 implementation.

https://github.com/OCA/account-fiscal-rule/blob/16.0/account_fiscal_position_type/demo/account_chart_template.xml