### PR TITLE
[16.0][FIX] account_fiscal_position_type: use company from move

### DIFF
--- a/account_fiscal_position_type/models/account_move.py
+++ b/account_fiscal_position_type/models/account_move.py
@@ -27,7 +27,7 @@ class AccountMove(models.Model):
     def _compute_suitable_journal_ids(self):
         res = super()._compute_suitable_journal_ids()
         for m in self:
-            domain = [("company_id", "=", self.env.company.id)]
+            domain = [("company_id", "=", m.company_id.id or self.env.company.id)]
             if m.invoice_filter_type_domain in ["sale", "purchase"]:
                 domain = expression.AND(
                     [


### PR DESCRIPTION
otherwise you have to switch company for editing fiscal positions of moves from another company than the active one