### PR TITLE
[16.0] add configuration to ignore warning avatax missing configuratio…

### DIFF
--- a/account_avatax_oca/__manifest__.py
+++ b/account_avatax_oca/__manifest__.py
@@ -24,6 +24,7 @@
         "views/account_move_view.xml",
         "views/account_tax_view.xml",
         "views/account_fiscal_position_view.xml",
+        "views/res_config_settings_views.xml",
     ],
     "demo": ["demo/avatax_demo.xml"],
     "images": ["static/description/avatax_icon.png"],

--- a/account_avatax_oca/models/__init__.py
+++ b/account_avatax_oca/models/__init__.py
@@ -6,3 +6,4 @@ from . import account_fiscal_position
 from . import account_tax
 from . import res_company
 from . import avatax_rest_api
+from . import res_config

--- a/account_avatax_oca/models/res_company.py
+++ b/account_avatax_oca/models/res_company.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import _, models
+from odoo import _, fields, models
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -8,21 +8,32 @@ _LOGGER = logging.getLogger(__name__)
 class Company(models.Model):
     _inherit = "res.company"
 
+    allow_avatax_configuration = fields.Boolean(
+        string="Active Avatax for this company",
+        default=True,
+        readonly=False,
+    )
+
     def get_avatax_config_company(self):
         """Returns the AvaTax configuration for the Company"""
         if self:
             self.ensure_one()
             AvataxConfig = self.env["avalara.salestax"]
-            res = AvataxConfig.search(
-                [("company_id", "=", self.id), ("disable_tax_calculation", "=", False)]
-            )
-            if len(res) > 1:
-                _LOGGER.warning(
-                    _("Company %s has too many Avatax configurations!"),
-                    self.display_name,
+            if self.allow_avatax_configuration:
+                res = AvataxConfig.search(
+                    [
+                        ("company_id", "=", self.id),
+                        ("disable_tax_calculation", "=", False),
+                    ]
                 )
-            if len(res) < 1:
-                _LOGGER.warning(
-                    _("Company %s has no Avatax configuration."), self.display_name
-                )
-            return res and res[0]
+                if len(res) > 1:
+                    _LOGGER.warning(
+                        _("Company %s has too many Avatax configurations!"),
+                        self.display_name,
+                    )
+                if len(res) < 1:
+                    _LOGGER.warning(
+                        _("Company %s has no Avatax configuration."), self.display_name
+                    )
+                return res and res[0]
+            return AvataxConfig

--- a/account_avatax_oca/models/res_config.py
+++ b/account_avatax_oca/models/res_config.py
@@ -1,0 +1,15 @@
+#   Copyright (c) 2024 Groupe Voltaire
+#   @author Emilie SOUTIRAS  <emilie.soutiras@groupevoltaire.com>
+#   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    allow_avatax_configuration = fields.Boolean(
+        string="Active Avatax for this company",
+        related="company_id.allow_avatax_configuration",
+        readonly=False,
+    )

--- a/account_avatax_oca/tests/test_account_tax.py
+++ b/account_avatax_oca/tests/test_account_tax.py
@@ -25,3 +25,28 @@ class TestAvatax(common.TransactionCase):
     def test_get_avatax_template_missing(self):
         with self.assertRaises(exceptions.UserError):
             self.Tax.with_company(self.company2).get_avalara_tax(0, "out_invoice")
+
+    def test_get_avatax_config_company_missing(self):
+        logger_name = "odoo.addons.account_avatax_oca.models.res_company"
+        with self.assertLogs(logger_name) as watcher:
+            res = self.company2.get_avatax_config_company()
+            expected_msg = "Company Company Avatax 2 has no Avatax configuration."
+            self.assertIn(expected_msg, watcher.output[0])
+            self.assertFalse(res.invoice_calculate_tax)
+            self.assertFalse(res.validation_on_save)
+
+    def test_get_avatax_config_company_no_config(self):
+        logger_name = "odoo.addons.account_avatax_oca.models.res_company"
+        self.company2.allow_avatax_configuration = False
+        res = self.company2.get_avatax_config_company()
+        self.assertFalse(res.invoice_calculate_tax)
+        self.assertFalse(res.validation_on_save)
+        # test no log
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(logger_name, "DEBUG") as watcher:
+                self.company2.get_avatax_config_company()
+                expected_msg = "Company Company Avatax 2 has no Avatax configuration."
+                self.assertNotIn(
+                    expected_msg,
+                    watcher.output[0] if watcher.output else watcher.output,
+                )

--- a/account_avatax_oca/views/res_config_settings_views.xml
+++ b/account_avatax_oca/views/res_config_settings_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ #  Copyright (c) 2024 Groupe Voltaire
+  ~ #  @author Emilie SOUTIRAS  <emilie.soutiras@groupevoltaire.com>
+  ~ #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@name='default_taxes_setting_container']"
+                position="inside"
+            >
+                <div class="col-12 col-lg-6 o_setting_box" id="avatax_configuration">
+                    <div class="o_setting_left_pane">
+                        <field name="allow_avatax_configuration" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="allow_avatax_configuration" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                            role="img"
+                        />
+                        <div class="text-muted">
+                            Avoid the selection of multiple VAT taxes.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
…n on specific companies

In the case of multiple companies in Odoo, some may not need Avatax configuration and warning messages.
The suggestion here is to add a parameter on the company so as not to search for the Avatax configuration.

(recreate from closed PR https://github.com/OCA/account-fiscal-rule/pull/438)