### PR TITLE
[17.0][FIX] account_avatax[_sale]_oca: present theoretical tax rate on invoices

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -2,7 +2,6 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -237,60 +236,17 @@ class AccountMove(models.Model):
             return tax_result
 
         if self.state == "draft":
-            Tax = self.env["account.tax"]
-            tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
-            taxes_to_set = {}
+            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
             for line in self.invoice_line_ids:
-                tax_result_line = tax_result_lines.get(line.id)
-                if tax_result_line:
-                    # rate = tax_result_line.get("rate", 0.0)
-                    tax_calculation = 0.0
-                    if tax_result_line["taxableAmount"]:
-                        tax_calculation = (
-                            tax_result_line["taxCalculated"]
-                            / tax_result_line["taxableAmount"]
-                        )
-                    rate = round(tax_calculation * 100, 4)
-                    tax = Tax.get_avalara_tax(rate, doc_type)
-                    if tax and tax not in line.tax_ids:
-                        line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
-                        taxes_to_set[line.id] = line_taxes | tax
-                    line.avatax_amt_line = tax_result_line["tax"]
-            self.with_context(check_move_validity=False).avatax_amount = tax_result[
-                "totalTax"
-            ]
-            container = {"records": self}
-
-            # Set Taxes on lines in a way that properly triggers onchanges
-            # This same approach is also used by the official account_taxcloud connector
-            with self.with_context(
-                avatax_invoice=self, check_move_validity=False
-            )._sync_dynamic_lines(container), self.line_ids.mapped(
-                "move_id"
-            )._check_balanced(container):
-                for line_id in taxes_to_set.keys():
-                    line = self.invoice_line_ids.filtered(
-                        lambda x, line_id=line_id: x.id == line_id
+                line_tax = tax_result_lines.get(line.id, {})
+                tax = line_tax.get("tax_id")
+                if tax and tax not in line.tax_ids:
+                    line.tax_ids = (
+                        line.tax_ids.filtered(lambda x: not x.is_avatax) | tax
                     )
-                    line.write({"tax_ids": [(6, 0, [])]})
-                    line.with_context(
-                        avatax_invoice=self, check_move_validity=False
-                    ).write({"tax_ids": taxes_to_set.get(line_id).ids})
-            # After taxes are changed is needed to force compute taxes again,
-            # in 16 version change of tax doesn't trigger compute of taxes
-            # on header for unknown reason
-            self._compute_amount()
-            if float_compare(
-                self.amount_untaxed + max(self.amount_tax, abs(self.avatax_amount)),
-                self.amount_residual,
-                precision_rounding=self.currency_id.rounding or 0.001,
-            ):
-                taxes_data = {
-                    iline.id: iline.tax_ids for iline in self.invoice_line_ids
-                }
-                self.invoice_line_ids.write({"tax_ids": [(6, 0, [])]})
-                for line in self.invoice_line_ids:
-                    line.write({"tax_ids": taxes_data[line.id].ids})
+                line.avatax_amt_line = line_tax.get("tax_amount", 0.0)
+            self.avatax_amount = tax_result.get("totalTax", 0.0)
+
         return tax_result
 
     # Same as v13

--- a/account_avatax_oca/models/account_tax.py
+++ b/account_avatax_oca/models/account_tax.py
@@ -12,29 +12,38 @@ class AccountTax(models.Model):
     is_avatax = fields.Boolean()
 
     @api.model
-    def _get_avalara_tax_domain(self, tax_rate, doc_type):
+    def _get_avalara_tax_domain(self, tax_rate):
         return [
             ("amount", "=", tax_rate),
             ("is_avatax", "=", True),
-            (
-                "company_id",
-                "=",
-                self.env.company.id,
-            ),
+            ("company_id", "=", self.env.company.id),
         ]
 
     @api.model
-    def _get_avalara_tax_name(self, tax_rate, doc_type=None):
-        return _("{}%*").format(str(tax_rate))
+    def _prepare_avalara_tax(self, real_rate, theoretical_rate=None):
+        # We now use the advertised tax rate
+        # plus the details of the real rate needed for Odoo
+        # to calculate the exact same tax amount without rounding differences
+        rate = round(theoretical_rate or real_rate, 2)
+        label = name = f"{rate}%"
+        if str(real_rate) != str(rate):
+            name += f" ({real_rate})"
+        return {
+            "amount": real_rate,
+            "name": name,
+            "invoice_label": label,
+            "active": True,
+        }
 
     @api.model
-    def get_avalara_tax(self, tax_rate, doc_type):
-        domain = self._get_avalara_tax_domain(tax_rate, doc_type)
-        tax = self.with_context(active_test=False).search(domain, limit=1)
-        if tax and not tax.active:
-            tax.active = True
+    def get_avalara_tax(self, tax_rate, display_rate=None):
+        vals = self._prepare_avalara_tax(tax_rate, display_rate)
+        domain = self._get_avalara_tax_domain(tax_rate)
+        # Better UX to not present 0% tax as AVATAX
+        domain += [("name", "not ilike", "AVATAX")]
+        tax = self.search(domain, limit=1)
         if not tax:
-            domain = self._get_avalara_tax_domain(0, doc_type)
+            domain = self._get_avalara_tax_domain(0)
             tax_template = self.search(domain, limit=1)
             if not tax_template:
                 raise exceptions.UserError(
@@ -43,10 +52,6 @@ class AccountTax(models.Model):
                 )
             # If you get a unique constraint error here,
             # check the data for your existing Avatax taxes.
-            vals = {
-                "amount": tax_rate,
-                "name": self._get_avalara_tax_name(tax_rate, doc_type),
-            }
             tax = tax_template.sudo().copy(default=vals)
             # Odoo core does not use the name set in default dict
             tax.name = vals.get("name")

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -331,3 +331,25 @@ class AvalaraSalestax(models.Model):
         client = AvaTaxRESTService(config=self)
         client.ping()
         return True
+
+    #
+    # AVATAX RESPONSE PARSING HELPERS
+    #
+
+    def get_avatax_line_tax(self, avatax_response):
+        """
+        Receives an Avatax API response JSON-like object
+        Returns a dict mapping line database IDs to the tax amount and ID:
+        {123: {"taxable": 200.0, "tax_amount": 20.0, "tax_id": account.tax(12)}, ...}
+        """
+        Tax = self.env["account.tax"]
+        res = {}
+        for line in avatax_response.get("lines", []):
+            taxable = line.get("taxableAmount", 0.0)
+            tax_amount = line.get("tax", 0.0)
+            rate = round(sum(x["rate"] for x in line.get("details", [])) * 100, 4)
+            real_rate = round(tax_amount * 100 / taxable if taxable else 0.0, 4)
+            tax = Tax.get_avalara_tax(real_rate, display_rate=rate)
+            line_id = int(line["lineNumber"])
+            res[line_id] = {"taxable": taxable, "tax_amount": tax_amount, "tax_id": tax}
+        return res

--- a/account_avatax_oca/tests/test_account_tax.py
+++ b/account_avatax_oca/tests/test_account_tax.py
@@ -15,13 +15,13 @@ class TestAvatax(common.TransactionCase):
         cls.company2 = cls.env["res.company"].create({"name": "Company Avatax 2"})
 
     def test_get_avatax_tax_rate(self):
-        tax75 = self.Tax.get_avalara_tax(7.5, "out_invoice")
+        tax75 = self.Tax.get_avalara_tax(7.5)
         self.assertEqual(tax75.amount, 7.5)
 
     def test_get_avatax_template(self):
-        tax = self.Tax.get_avalara_tax(0, "out_invoice")
-        self.assertEqual(tax.name, "AVATAX")
+        tax = self.Tax.get_avalara_tax(0)
+        self.assertEqual(tax.name, "0%")
 
     def test_get_avatax_template_missing(self):
         with self.assertRaises(exceptions.UserError):
-            self.Tax.with_company(self.company2).get_avalara_tax(0, "out_invoice")
+            self.Tax.with_company(self.company2).get_avalara_tax(0)

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -175,7 +175,6 @@ class SaleOrder(models.Model):
         # Override to handle lines with split taxes (e.g. TN)
         self and self.ensure_one()
         doc_type = self._get_avatax_doc_type()
-        Tax = self.env["account.tax"]
         avatax_config = self.company_id.get_avatax_config_company()
         if not avatax_config:
             return False
@@ -197,31 +196,15 @@ class SaleOrder(models.Model):
             currency_id=self.currency_id,
             log_to_record=self,
         )
-        tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
-        for line in self.order_line:
-            tax_result_line = tax_result_lines.get(line.id)
-            if tax_result_line:
-                # Should we check the rate with the tax amount?
-                # tax_amount = tax_result_line["taxCalculated"]
-                # rate = round(tax_amount / line.price_subtotal * 100, 2)
-                # rate = tax_result_line["rate"]
-                tax_calculation = 0.0
-                if tax_result_line["taxableAmount"]:
-                    tax_calculation = (
-                        tax_result_line["taxCalculated"]
-                        / tax_result_line["taxableAmount"]
-                    )
-                rate = round(tax_calculation * 100, 4)
-                tax = Tax.get_avalara_tax(rate, doc_type)
-                if tax not in line.tax_id:
-                    line_taxes = (
-                        tax
-                        if avatax_config.override_line_taxes
-                        else tax | line.tax_id.filtered(lambda x: not x.is_avatax)
-                    )
-                    line.tax_id = line_taxes
-                line.tax_amt = tax_result_line["tax"]
-        self.tax_amount = tax_result.get("totalTax")
+        if not (self.state == "cancel" or self.locked):
+            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
+            for line in self.order_line:
+                line_tax = tax_result_lines.get(line.id, {})
+                tax = line_tax.get("tax_id")
+                if tax and tax not in line.tax_id:
+                    line.tax_id = line.tax_id.filtered(lambda x: not x.is_avatax) | tax
+                line.tax_amt = line_tax.get("tax_amount", 0.0)
+            self.tax_amount = tax_result.get("totalTax")
         return True
 
     def avalara_compute_taxes(self):


### PR DESCRIPTION
Tax names used to represent taxes are changed, to show both the theoretical tax (e.g. "9.5%") and the real tax rate needed to Odoo to calculate the exact same cent value (e.g. "9.576%").
And on Invoiced we, want only the theoretical tax to be presented (e.g. "9.5%").
This was also a chance to refactor of the code related to Avalara tax code creation, that was reduced by removing redundancies.

Sample output for the the new Avalara tax naming approach:

![image](https://github.com/user-attachments/assets/08c88a69-321e-4ba9-9aee-24e9e4398460)


- [FIX] account_avatax_oca: present theoretical tax rate on invoices
- [FIX] account_avatax_sale_oca: present theoretical tax rate on invoices

