### PR TITLE
[IMP] account_avatax_exemption_base: remove chatter from wizard view

### DIFF
--- a/account_avatax_exemption_base/views/avalara_exemption_view.xml
+++ b/account_avatax_exemption_base/views/avalara_exemption_view.xml
@@ -199,11 +199,6 @@
                         </page>
                     </notebook>
                 </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
-                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
chatter in wizard view does not make sense, it caused an issue in 17.0 and 18.0 migrations.
despite we don't see the side effect in 16.0!