### PR TITLE
[16][account_ecotax] Store fields needed for reporting

### DIFF
--- a/account_ecotax/__manifest__.py
+++ b/account_ecotax/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Ecotax Management",
     "summary": "Ecotax Management:  in French context is a 'cost' "
     "added to the sale price of electrical or electronic appliances or furnishing items",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Akretion, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-fiscal-rule",
     "category": "Localization/Account Taxes",

--- a/account_ecotax/migrations/16.0.1.1.0/post-migration.py
+++ b/account_ecotax/migrations/16.0.1.1.0/post-migration.py
@@ -1,0 +1,42 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        SELECT *
+        FROM information_schema.columns
+        WHERE table_name='account_move_line_ecotax' and column_name='product_id';
+    """
+    )
+    # field could already be stored in case account_ecotax_report is installed.
+    # then no need to managed these new stored fields.
+    if cr.fetchall():
+        return
+    cr.execute(
+        """
+        ALTER TABLE account_move_line_ecotax ADD COLUMN product_id integer
+    """
+    )
+    cr.execute(
+        """
+        ALTER TABLE account_move_line_ecotax ADD COLUMN quantity numeric
+    """
+    )
+    cr.execute(
+        """
+        ALTER TABLE account_move_line_ecotax ADD COLUMN currency_id integer
+    """
+    )
+    cr.execute(
+        """
+        UPDATE account_move_line_ecotax
+        SET product_id = l.product_id,
+            quantity = l.quantity,
+            currency_id = l.currency_id
+        FROM account_move_line l
+        WHERE l.id = account_move_line_ecotax.account_move_line_id
+    """
+    )

--- a/account_ecotax/models/account_move_line_ecotax.py
+++ b/account_ecotax/models/account_move_line_ecotax.py
@@ -20,9 +20,14 @@ class AccountMoveLineEcotax(models.Model):
         ondelete="cascade",
     )
     product_id = fields.Many2one(
-        "product.product", related="account_move_line_id.product_id", readonly=True
+        "product.product",
+        related="account_move_line_id.product_id",
+        readonly=True,
+        store=True,
     )
-    quantity = fields.Float(related="account_move_line_id.quantity", readonly=True)
+    quantity = fields.Float(
+        related="account_move_line_id.quantity", readonly=True, store=True
+    )
     currency_id = fields.Many2one(
-        related="account_move_line_id.currency_id", readonly=True
+        related="account_move_line_id.currency_id", readonly=True, store=True
     )


### PR DESCRIPTION
It is actually stored in the module account_ecotax_report : https://github.com/OCA/account-fiscal-rule/pull/456
But this is not a good practice to change a not stored field to stored since Odoo will drop the column and re-create it at each update of account_ecotax.

Store it in base module as we do not really have reason not to IMO