### PR TITLE
[17.0][FIX] account_avatax[_sale]_oca: on multicompany, consider document company instead of env company (bump minor)

### DIFF
--- a/account_avatax_oca/data/avalara_salestax_data.xml
+++ b/account_avatax_oca/data/avalara_salestax_data.xml
@@ -7,6 +7,7 @@
     </record>
     <record id="avatax_tax_group" model="account.tax.group">
         <field name="name">AvaTax</field>
+        <field name="country_id" ref="base.us" />
     </record>
     <!-- Used as template for automatic Tax records created -->
     <record id="avatax" model="account.tax">

--- a/account_avatax_oca/data/neutralize.sql
+++ b/account_avatax_oca/data/neutralize.sql
@@ -1,0 +1,2 @@
+UPDATE avalara_salestax
+   SET service_url = 'https://sandbox-rest.avatax.com/api/v2'

--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -115,14 +115,13 @@ class AccountMove(models.Model):
     @api.model
     @api.depends("company_id")
     def _compute_hide_exemption(self):
-        avatax_config = self.env.company.get_avatax_config_company()
         for inv in self:
+            avatax_config = inv.company_id.avatax_configuration_id
             inv.hide_exemption = avatax_config.hide_exemption
 
     hide_exemption = fields.Boolean(
         "Hide Exemption & Tax Based on shipping address",
         compute=_compute_hide_exemption,  # For past transactions visibility
-        default=lambda self: self.env.company.get_avatax_config_company,
         help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
         "Also, it will show Tax based on shipping address button",
     )
@@ -163,7 +162,7 @@ class AccountMove(models.Model):
     # Same as v12
     def _get_avatax_doc_type(self, commit=True):
         self.ensure_one()
-        avatax_config = self.company_id.get_avatax_config_company()
+        avatax_config = self.company_id.avatax_configuration_id
         if avatax_config.disable_tax_reporting:
             commit = False
         if "refund" in self.move_type:
@@ -186,15 +185,15 @@ class AccountMove(models.Model):
         ]
         return [x for x in lines if x]
 
-    # Same as v12
     def _avatax_compute_tax(self, commit=False):
         """Contact REST API and recompute taxes for a Sale Order"""
         # Override to handle lines with split taxes (e.g. TN)
         self and self.ensure_one()
-        avatax_config = self.company_id.get_avatax_config_company()
+        avatax_config = self.company_id.avatax_configuration_id
         if not avatax_config:
             # Skip Avatax computation if no configuration is found
             return
+
         doc_type = self._get_avatax_doc_type(commit=commit)
         tax_date = self.get_origin_tax_date() or self.invoice_date
         taxable_lines = self._avatax_prepare_lines(doc_type)
@@ -235,17 +234,14 @@ class AccountMove(models.Model):
             avatax_config.commit_transaction(self.name, doc_type)
             return tax_result
 
-        if self.state == "draft":
-            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
-            for line in self.invoice_line_ids:
-                line_tax = tax_result_lines.get(line.id, {})
-                tax = line_tax.get("tax_id")
-                if tax and tax not in line.tax_ids:
-                    line.tax_ids = (
-                        line.tax_ids.filtered(lambda x: not x.is_avatax) | tax
-                    )
-                line.avatax_amt_line = line_tax.get("tax_amount", 0.0)
-            self.avatax_amount = tax_result.get("totalTax", 0.0)
+        tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
+        for line in self.invoice_line_ids:
+            line_tax = tax_result_lines.get(line.id, {})
+            tax = line_tax.get("tax_id")
+            if tax and tax not in line.tax_ids:
+                line.tax_ids = line.tax_ids.filtered(lambda x: not x.is_avatax) | tax
+            line.avatax_amt_line = line_tax.get("tax_amount", 0.0)
+        self.avatax_amount = tax_result.get("totalTax", 0.0)
 
         return tax_result
 
@@ -266,7 +262,7 @@ class AccountMove(models.Model):
 
     def avatax_commit_taxes(self):
         for invoice in self:
-            avatax_config = invoice.company_id.get_avatax_config_company()
+            avatax_config = invoice.company_id.avatax_configuration_id
             if not avatax_config.disable_tax_reporting:
                 doc_type = invoice._get_avatax_doc_type()
                 avatax_config.commit_transaction(invoice.name, doc_type)
@@ -282,7 +278,7 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         for invoice in self:
             if invoice.is_avatax_calculated():
-                avatax_config = self.company_id.get_avatax_config_company()
+                avatax_config = invoice.company_id.avatax_configuration_id
                 if avatax_config and avatax_config.force_address_validation:
                     for addr in [self.partner_id, self.partner_shipping_id]:
                         if not addr.date_validation:
@@ -335,7 +331,7 @@ class AccountMove(models.Model):
         )
         res = super().button_draft()
         for invoice in posted_invoices:
-            avatax_config = invoice.company_id.get_avatax_config_company()
+            avatax_config = invoice.company_id.avatax_configuration_id
             if avatax_config:
                 doc_type = invoice._get_avatax_doc_type()
                 avatax_config.void_transaction(invoice.name, doc_type)
@@ -349,7 +345,7 @@ class AccountMove(models.Model):
         "partner_id",
     )
     def onchange_avatax_calculation(self):
-        avatax_config = self.env.company.get_avatax_config_company()
+        avatax_config = self.company_id.avatax_configuration_id
         self.calculate_tax_on_save = False
         if avatax_config.invoice_calculate_tax:
             if (
@@ -371,29 +367,29 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         result = super().write(vals)
-        avatax_config = self.env.company.get_avatax_config_company()
-        for record in self:
+        for move in self:
+            avatax_config = move.company_id.avatax_configuration_id
             if (
                 avatax_config.invoice_calculate_tax
-                and record.calculate_tax_on_save
-                and record.state == "draft"
-                and not self._context.get("skip_second_write", False)
+                and move.calculate_tax_on_save
+                and move.state == "draft"
+                and not self.env.context.get("skip_second_write", False)
             ):
-                record.with_context(skip_second_write=True).write(
+                move.with_context(skip_second_write=True).write(
                     {"calculate_tax_on_save": False}
                 )
-                record.avatax_compute_taxes()
+                move.avatax_compute_taxes()
         return result
 
     @api.model_create_multi
     def create(self, vals_list):
         moves = super().create(vals_list)
-        avatax_config = self.env.company.get_avatax_config_company()
         for move in moves:
+            avatax_config = move.company_id.avatax_configuration_id
             if (
                 avatax_config.invoice_calculate_tax
                 and move.calculate_tax_on_save
-                and not self._context.get("skip_second_write", False)
+                and not self.env.context.get("skip_second_write", False)
             ):
                 move.with_context(skip_second_write=True).write(
                     {"calculate_tax_on_save": False}
@@ -449,7 +445,7 @@ class AccountMoveLine(models.Model):
         line = self
         res = {}
         # Add UPC to product item code
-        avatax_config = line.company_id.get_avatax_config_company()
+        avatax_config = line.company_id.avatax_configuration_id
         product = line.product_id
         if product.barcode and avatax_config.upc_enable:
             item_code = "UPC:%d" % product.barcode

--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -2,7 +2,6 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -237,60 +236,17 @@ class AccountMove(models.Model):
             return tax_result
 
         if self.state == "draft":
-            Tax = self.env["account.tax"]
-            tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
-            taxes_to_set = {}
+            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
             for line in self.invoice_line_ids:
-                tax_result_line = tax_result_lines.get(line.id)
-                if tax_result_line:
-                    # rate = tax_result_line.get("rate", 0.0)
-                    tax_calculation = 0.0
-                    if tax_result_line["taxableAmount"]:
-                        tax_calculation = (
-                            tax_result_line["taxCalculated"]
-                            / tax_result_line["taxableAmount"]
-                        )
-                    rate = round(tax_calculation * 100, 4)
-                    tax = Tax.get_avalara_tax(rate, doc_type)
-                    if tax and tax not in line.tax_ids:
-                        line_taxes = line.tax_ids.filtered(lambda x: not x.is_avatax)
-                        taxes_to_set[line.id] = line_taxes | tax
-                    line.avatax_amt_line = tax_result_line["tax"]
-            self.with_context(check_move_validity=False).avatax_amount = tax_result[
-                "totalTax"
-            ]
-            container = {"records": self}
-
-            # Set Taxes on lines in a way that properly triggers onchanges
-            # This same approach is also used by the official account_taxcloud connector
-            with self.with_context(
-                avatax_invoice=self, check_move_validity=False
-            )._sync_dynamic_lines(container), self.line_ids.mapped(
-                "move_id"
-            )._check_balanced(container):
-                for line_id in taxes_to_set.keys():
-                    line = self.invoice_line_ids.filtered(
-                        lambda x, line_id=line_id: x.id == line_id
+                line_tax = tax_result_lines.get(line.id, {})
+                tax = line_tax.get("tax_id")
+                if tax and tax not in line.tax_ids:
+                    line.tax_ids = (
+                        line.tax_ids.filtered(lambda x: not x.is_avatax) | tax
                     )
-                    line.write({"tax_ids": [(6, 0, [])]})
-                    line.with_context(
-                        avatax_invoice=self, check_move_validity=False
-                    ).write({"tax_ids": taxes_to_set.get(line_id).ids})
-            # After taxes are changed is needed to force compute taxes again,
-            # in 16 version change of tax doesn't trigger compute of taxes
-            # on header for unknown reason
-            self._compute_amount()
-            if float_compare(
-                self.amount_untaxed + max(self.amount_tax, abs(self.avatax_amount)),
-                self.amount_residual,
-                precision_rounding=self.currency_id.rounding or 0.001,
-            ):
-                taxes_data = {
-                    iline.id: iline.tax_ids for iline in self.invoice_line_ids
-                }
-                self.invoice_line_ids.write({"tax_ids": [(6, 0, [])]})
-                for line in self.invoice_line_ids:
-                    line.write({"tax_ids": taxes_data[line.id].ids})
+                line.avatax_amt_line = line_tax.get("tax_amount", 0.0)
+            self.avatax_amount = tax_result.get("totalTax", 0.0)
+
         return tax_result
 
     # Same as v13

--- a/account_avatax_oca/models/account_tax.py
+++ b/account_avatax_oca/models/account_tax.py
@@ -12,29 +12,38 @@ class AccountTax(models.Model):
     is_avatax = fields.Boolean()
 
     @api.model
-    def _get_avalara_tax_domain(self, tax_rate, doc_type):
+    def _get_avalara_tax_domain(self, tax_rate):
         return [
             ("amount", "=", tax_rate),
             ("is_avatax", "=", True),
-            (
-                "company_id",
-                "=",
-                self.env.company.id,
-            ),
+            ("company_id", "=", self.env.company.id),
         ]
 
     @api.model
-    def _get_avalara_tax_name(self, tax_rate, doc_type=None):
-        return _("{}%*").format(str(tax_rate))
+    def _prepare_avalara_tax(self, real_rate, theoretical_rate=None):
+        # We now use the advertised tax rate
+        # plus the details of the real rate needed for Odoo
+        # to calculate the exact same tax amount without rounding differences
+        rate = round(theoretical_rate or real_rate, 2)
+        label = name = f"{rate}%"
+        if str(real_rate) != str(rate):
+            name += f" ({real_rate})"
+        return {
+            "amount": real_rate,
+            "name": name,
+            "invoice_label": label,
+            "active": True,
+        }
 
     @api.model
-    def get_avalara_tax(self, tax_rate, doc_type):
-        domain = self._get_avalara_tax_domain(tax_rate, doc_type)
-        tax = self.with_context(active_test=False).search(domain, limit=1)
-        if tax and not tax.active:
-            tax.active = True
+    def get_avalara_tax(self, tax_rate, display_rate=None):
+        vals = self._prepare_avalara_tax(tax_rate, display_rate)
+        domain = self._get_avalara_tax_domain(tax_rate)
+        # Better UX to not present 0% tax as AVATAX
+        domain += [("name", "not ilike", "AVATAX")]
+        tax = self.search(domain, limit=1)
         if not tax:
-            domain = self._get_avalara_tax_domain(0, doc_type)
+            domain = self._get_avalara_tax_domain(0)
             tax_template = self.search(domain, limit=1)
             if not tax_template:
                 raise exceptions.UserError(
@@ -43,10 +52,6 @@ class AccountTax(models.Model):
                 )
             # If you get a unique constraint error here,
             # check the data for your existing Avatax taxes.
-            vals = {
-                "amount": tax_rate,
-                "name": self._get_avalara_tax_name(tax_rate, doc_type),
-            }
             tax = tax_template.sudo().copy(default=vals)
             # Odoo core does not use the name set in default dict
             tax.name = vals.get("name")

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -157,13 +157,13 @@ class AvalaraSalestax(models.Model):
     _sql_constraints = [
         (
             "code_company_uniq",
-            "unique (company_code)",
-            "Avalara setting is already available for this company code",
+            "unique (company_id)",
+            _("Only one Avatax configuration per company allowed."),
         ),
         (
             "account_number_company_uniq",
             "unique (account_number, company_id)",
-            "The account number must be unique per company!",
+            _("The account number must be unique per company!"),
         ),
     ]
 
@@ -342,13 +342,13 @@ class AvalaraSalestax(models.Model):
         Returns a dict mapping line database IDs to the tax amount and ID:
         {123: {"taxable": 200.0, "tax_amount": 20.0, "tax_id": account.tax(12)}, ...}
         """
-        Tax = self.env["account.tax"]
         res = {}
         for line in avatax_response.get("lines", []):
             taxable = line.get("taxableAmount", 0.0)
             tax_amount = line.get("tax", 0.0)
             rate = round(sum(x["rate"] for x in line.get("details", [])) * 100, 4)
             real_rate = round(tax_amount * 100 / taxable if taxable else 0.0, 4)
+            Tax = self.env["account.tax"].sudo().with_company(self.company_id)
             tax = Tax.get_avalara_tax(real_rate, display_rate=rate)
             line_id = int(line["lineNumber"])
             res[line_id] = {"taxable": taxable, "tax_amount": tax_amount, "tax_id": tax}

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -331,3 +331,25 @@ class AvalaraSalestax(models.Model):
         client = AvaTaxRESTService(config=self)
         client.ping()
         return True
+
+    #
+    # AVATAX RESPONSE PARSING HELPERS
+    #
+
+    def get_avatax_line_tax(self, avatax_response):
+        """
+        Receives an Avatax API response JSON-like object
+        Returns a dict mapping line database IDs to the tax amount and ID:
+        {123: {"taxable": 200.0, "tax_amount": 20.0, "tax_id": account.tax(12)}, ...}
+        """
+        Tax = self.env["account.tax"]
+        res = {}
+        for line in avatax_response.get("lines", []):
+            taxable = line.get("taxableAmount", 0.0)
+            tax_amount = line.get("tax", 0.0)
+            rate = round(sum(x["rate"] for x in line.get("details", [])) * 100, 4)
+            real_rate = round(tax_amount * 100 / taxable if taxable else 0.0, 4)
+            tax = Tax.get_avalara_tax(real_rate, display_rate=rate)
+            line_id = int(line["lineNumber"])
+            res[line_id] = {"taxable": taxable, "tax_amount": tax_amount, "tax_id": tax}
+        return res

--- a/account_avatax_oca/models/partner.py
+++ b/account_avatax_oca/models/partner.py
@@ -153,7 +153,9 @@ class ResPartner(models.Model):
                 partner.display_name,
             )
             return False
-        avatax_config = self.env.company.get_avatax_config_company()
+        company = self.company_id or self.env.company
+        avatax_config = company.avatax_configuration_id
+
         # Skip automatic validation for countries not supported by Avatax
         supported_countries = [x.code for x in avatax_config.country_ids]
         country_code = partner.country_id.code
@@ -210,8 +212,9 @@ class ResPartner(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         partners = super().create(vals_list)
-        avatax_config = self.env.company.get_avatax_config_company()
         for partner in partners:
+            company = partner.company_id or self.env.company
+            avatax_config = company.avatax_configuration_id
             # Auto populate customer code, if not provided
             if not partner.customer_code:
                 partner.generate_cust_code()
@@ -228,7 +231,8 @@ class ResPartner(models.Model):
             x in vals for x in address_fields
         ):
             partner = self.with_context(avatax_writing=True)
-            avatax_config = self.env.company.get_avatax_config_company()
+            company = partner.company_id or self.env.company
+            avatax_config = company.avatax_configuration_id
             if avatax_config.validation_on_save:
                 partner.multi_address_validation(validation_on_save=True)
                 partner.validated_on_save = True

--- a/account_avatax_oca/models/res_company.py
+++ b/account_avatax_oca/models/res_company.py
@@ -1,28 +1,8 @@
-import logging
-
-from odoo import _, models
-
-_LOGGER = logging.getLogger(__name__)
+from odoo import fields, models
 
 
 class Company(models.Model):
     _inherit = "res.company"
 
-    def get_avatax_config_company(self):
-        """Returns the AvaTax configuration for the Company"""
-        if self:
-            self.ensure_one()
-            AvataxConfig = self.env["avalara.salestax"]
-            res = AvataxConfig.search(
-                [("company_id", "=", self.id), ("disable_tax_calculation", "=", False)]
-            )
-            if len(res) > 1:
-                _LOGGER.warning(
-                    _("Company %s has too many Avatax configurations!"),
-                    self.display_name,
-                )
-            if len(res) < 1:
-                _LOGGER.warning(
-                    _("Company %s has no Avatax configuration."), self.display_name
-                )
-            return res and res[0]
+    # Although it is a One2many field, is is ensured to be one or zero records
+    avatax_configuration_id = fields.One2many("avalara.salestax", "company_id")

--- a/account_avatax_oca/tests/test_account_tax.py
+++ b/account_avatax_oca/tests/test_account_tax.py
@@ -15,13 +15,13 @@ class TestAvatax(common.TransactionCase):
         cls.company2 = cls.env["res.company"].create({"name": "Company Avatax 2"})
 
     def test_get_avatax_tax_rate(self):
-        tax75 = self.Tax.get_avalara_tax(7.5, "out_invoice")
+        tax75 = self.Tax.get_avalara_tax(7.5)
         self.assertEqual(tax75.amount, 7.5)
 
     def test_get_avatax_template(self):
-        tax = self.Tax.get_avalara_tax(0, "out_invoice")
-        self.assertEqual(tax.name, "AVATAX")
+        tax = self.Tax.get_avalara_tax(0)
+        self.assertEqual(tax.name, "0%")
 
     def test_get_avatax_template_missing(self):
         with self.assertRaises(exceptions.UserError):
-            self.Tax.with_company(self.company2).get_avalara_tax(0, "out_invoice")
+            self.Tax.with_company(self.company2).get_avalara_tax(0)

--- a/account_avatax_oca/tests/test_avatax.py
+++ b/account_avatax_oca/tests/test_avatax.py
@@ -55,9 +55,6 @@ class TestAvatax(common.TransactionCase):
         self.invoice.button_draft()
 
     @patch(
-        "odoo.addons.account_avatax_oca.models.res_company.Company.get_avatax_config_company"
-    )
-    @patch(
         "odoo.addons.account_avatax_oca.models.avalara_salestax.AvalaraSalestax.create_transaction"  # noqa: B950
     )
     @patch(
@@ -67,7 +64,6 @@ class TestAvatax(common.TransactionCase):
         self,
         mock_void_transaction,
         mock_create_transaction,
-        mock_get_avatax_config_company,
     ):
         avatax_config = self.env["avalara.salestax"].create(
             {
@@ -76,9 +72,9 @@ class TestAvatax(common.TransactionCase):
                 "company_code": "DEFAULT",
                 "disable_tax_calculation": False,
                 "invoice_calculate_tax": False,
+                "company_id": self.env.company.id,
             }
         )
-        mock_get_avatax_config_company.return_value = avatax_config
 
         # Force empty taxes to check only avatax taxes
         self.invoice.invoice_line_ids.write(
@@ -143,7 +139,6 @@ class TestAvatax(common.TransactionCase):
             self.invoice.amount_tax + self.invoice.amount_untaxed,
             self.invoice.amount_residual,
         )
-        mock_get_avatax_config_company.assert_called()
         mock_create_transaction.assert_called()
 
         mock_void_transaction.return_value = {"status": "success"}

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -175,7 +175,6 @@ class SaleOrder(models.Model):
         # Override to handle lines with split taxes (e.g. TN)
         self and self.ensure_one()
         doc_type = self._get_avatax_doc_type()
-        Tax = self.env["account.tax"]
         avatax_config = self.company_id.get_avatax_config_company()
         if not avatax_config:
             return False
@@ -197,31 +196,15 @@ class SaleOrder(models.Model):
             currency_id=self.currency_id,
             log_to_record=self,
         )
-        tax_result_lines = {int(x["lineNumber"]): x for x in tax_result["lines"]}
-        for line in self.order_line:
-            tax_result_line = tax_result_lines.get(line.id)
-            if tax_result_line:
-                # Should we check the rate with the tax amount?
-                # tax_amount = tax_result_line["taxCalculated"]
-                # rate = round(tax_amount / line.price_subtotal * 100, 2)
-                # rate = tax_result_line["rate"]
-                tax_calculation = 0.0
-                if tax_result_line["taxableAmount"]:
-                    tax_calculation = (
-                        tax_result_line["taxCalculated"]
-                        / tax_result_line["taxableAmount"]
-                    )
-                rate = round(tax_calculation * 100, 4)
-                tax = Tax.get_avalara_tax(rate, doc_type)
-                if tax not in line.tax_id:
-                    line_taxes = (
-                        tax
-                        if avatax_config.override_line_taxes
-                        else tax | line.tax_id.filtered(lambda x: not x.is_avatax)
-                    )
-                    line.tax_id = line_taxes
-                line.tax_amt = tax_result_line["tax"]
-        self.tax_amount = tax_result.get("totalTax")
+        if not (self.state == "cancel" or self.locked):
+            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
+            for line in self.order_line:
+                line_tax = tax_result_lines.get(line.id, {})
+                tax = line_tax.get("tax_id")
+                if tax and tax not in line.tax_id:
+                    line.tax_id = line.tax_id.filtered(lambda x: not x.is_avatax) | tax
+                line.tax_amt = line_tax.get("tax_amount", 0.0)
+            self.tax_amount = tax_result.get("totalTax")
         return True
 
     def avalara_compute_taxes(self):

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -1,4 +1,8 @@
+import logging
+
 from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class SaleOrder(models.Model):
@@ -16,14 +20,13 @@ class SaleOrder(models.Model):
     @api.model
     @api.depends("company_id", "partner_id", "partner_invoice_id", "state")
     def _compute_hide_exemption(self):
-        avatax_config = self.env.company.get_avatax_config_company()
         for order in self:
+            avatax_config = order.company_id.avatax_configuration_id
             order.hide_exemption = avatax_config.hide_exemption
 
     hide_exemption = fields.Boolean(
         "Hide Exemption & Tax Based on shipping address",
         compute="_compute_hide_exemption",  # For past transactions visibility
-        default=lambda self: self.env.company.get_avatax_config_company,
         help="Uncheck the this field to show exemption fields on SO/Invoice form view. "
         "Also, it will show Tax based on shipping address button",
     )
@@ -172,15 +175,21 @@ class SaleOrder(models.Model):
 
     def _avatax_compute_tax(self):
         """Contact REST API and recompute taxes for a Sale Order"""
-        # Override to handle lines with split taxes (e.g. TN)
         self and self.ensure_one()
-        doc_type = self._get_avatax_doc_type()
-        avatax_config = self.company_id.get_avatax_config_company()
+        if self.state == "cancel" or self.locked:
+            # Exit early if no tax is to be recalculated
+            _logger.warning(
+                "Order %s is locked or cancelled, can't recompute tax", self.name
+            )
+            return False
+
+        avatax_config = self.company_id.avatax_configuration_id
         if not avatax_config:
             return False
         partner = self.partner_id
         if avatax_config.use_partner_invoice_id:
             partner = self.partner_invoice_id
+        doc_type = self._get_avatax_doc_type()
         taxable_lines = self._avatax_prepare_lines(self.order_line)
         tax_result = avatax_config.create_transaction(
             self.date_order,
@@ -196,15 +205,14 @@ class SaleOrder(models.Model):
             currency_id=self.currency_id,
             log_to_record=self,
         )
-        if not (self.state == "cancel" or self.locked):
-            tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
-            for line in self.order_line:
-                line_tax = tax_result_lines.get(line.id, {})
-                tax = line_tax.get("tax_id")
-                if tax and tax not in line.tax_id:
-                    line.tax_id = line.tax_id.filtered(lambda x: not x.is_avatax) | tax
-                line.tax_amt = line_tax.get("tax_amount", 0.0)
-            self.tax_amount = tax_result.get("totalTax")
+        tax_result_lines = avatax_config.get_avatax_line_tax(tax_result)
+        for line in self.order_line:
+            line_tax = tax_result_lines.get(line.id, {})
+            tax = line_tax.get("tax_id")
+            if tax and tax not in line.tax_id:
+                line.tax_id = line.tax_id.filtered(lambda x: not x.is_avatax) | tax
+            line.tax_amt = line_tax.get("tax_amount", 0.0)
+        self.tax_amount = tax_result.get("totalTax")
         return True
 
     def avalara_compute_taxes(self):
@@ -218,15 +226,16 @@ class SaleOrder(models.Model):
         return True
 
     def action_confirm(self):
-        avatax_config = self.company_id.get_avatax_config_company()
-        if avatax_config and avatax_config.force_address_validation:
-            for addr in [self.partner_id, self.partner_shipping_id]:
-                if not addr.date_validation:
-                    # The Confirm action will be interrupted
-                    # if the address is not validated
-                    return addr.button_avatax_validate_address()
-        if avatax_config:
-            self.avalara_compute_taxes()
+        for order in self:
+            avatax_config = order.company_id.avatax_configuration_id
+            if avatax_config and avatax_config.force_address_validation:
+                for addr in [order.partner_id, order.partner_shipping_id]:
+                    if not addr.date_validation:
+                        # The Confirm action will be interrupted
+                        # if the address is not validated
+                        return addr.button_avatax_validate_address()
+            if avatax_config:
+                order.avalara_compute_taxes()
         return super().action_confirm()
 
     @api.onchange(
@@ -236,7 +245,7 @@ class SaleOrder(models.Model):
         "partner_id",
     )
     def onchange_avatax_calculation(self):
-        avatax_config = self.env.company.get_avatax_config_company()
+        avatax_config = self.company_id.avatax_configuration_id
         self.calculate_tax_on_save = False
         if avatax_config.sale_calculate_tax:
             if (
@@ -259,37 +268,33 @@ class SaleOrder(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         sales = super().create(vals_list)
-        avatax_config = self.env.company.get_avatax_config_company()
         for sale in sales:
+            avatax_config = sale.company_id.avatax_configuration_id
             if (
                 avatax_config.sale_calculate_tax
                 and sale.calculate_tax_on_save
-                and not self._context.get("skip_second_write", False)
+                and not self.env.context.get("skip_second_write", False)
             ):
                 sale.with_context(skip_second_write=True).write(
-                    {
-                        "calculate_tax_on_save": False,
-                    }
+                    {"calculate_tax_on_save": False}
                 )
                 sale.avalara_compute_taxes()
         return sales
 
     def write(self, vals):
         result = super().write(vals)
-        avatax_config = self.env.company.get_avatax_config_company()
-        for record in self:
+        for sale in self:
+            avatax_config = sale.company_id.avatax_configuration_id
             if (
                 avatax_config.sale_calculate_tax
-                and record.calculate_tax_on_save
-                and record.state != "done"
-                and not self._context.get("skip_second_write", False)
+                and sale.calculate_tax_on_save
+                and sale.state != "done"
+                and not self.env.context.get("skip_second_write", False)
             ):
-                record.with_context(skip_second_write=True).write(
-                    {
-                        "calculate_tax_on_save": False,
-                    }
+                sale.with_context(skip_second_write=True).write(
+                    {"calculate_tax_on_save": False}
                 )
-                record.avalara_compute_taxes()
+                sale.avalara_compute_taxes()
         return result
 
 
@@ -306,7 +311,7 @@ class SaleOrderLine(models.Model):
         line = self
         res = {}
         # Add UPC to product item code
-        avatax_config = line.company_id.get_avatax_config_company()
+        avatax_config = line.company_id.avatax_configuration_id
         product = line.product_id
         if product.barcode and avatax_config.upc_enable:
             item_code = "UPC:%d" % product.barcode

--- a/account_avatax_sale_oca/views/sale_order_view.xml
+++ b/account_avatax_sale_oca/views/sale_order_view.xml
@@ -13,7 +13,7 @@
                     name="avalara_compute_taxes"
                     type="object"
                     string="Compute Taxes"
-                    invisible="is_avatax == False or state in ('done', 'cancel')"
+                    invisible="is_avatax == False or state in ('done', 'cancel') or locked"
                 />
             </button>
             <field name="payment_term_id" position="after">


### PR DESCRIPTION
Taxes are wrong if user with a non-Avatax active company calculates taxes for an invoice of an Avatax-company.
Fixes usages of `self.env.company` with the document's company. 
Simplifies the access to the Avatax configuration, and in the process removes the annoying warnings in the log.

Changes (commits to review here):
- FIX] account_avatax_oca: Install on multi-country
- [FIX] account_avatax_oca: on multicompany, consider document company instead of env company
- [FIX] account_avatax_sale_oca: on multicompany, consider document company instead of env company

Dependencies (included):
- [ ]  #479
- [x] https://github.com/OCA/account-fiscal-rule/pull/499 
