### PR TITLE
[16] account_ecotax and account_ecotax_sale  init computed fields on installation

### DIFF
--- a/account_ecotax/__init__.py
+++ b/account_ecotax/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hook import pre_init_hook

--- a/account_ecotax/__manifest__.py
+++ b/account_ecotax/__manifest__.py
@@ -28,4 +28,5 @@
         "report/invoice.xml",
     ],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_ecotax/hook.py
+++ b/account_ecotax/hook.py
@@ -1,0 +1,29 @@
+def pre_init_hook(cr):
+
+    cr.execute(
+        """
+        ALTER TABLE account_move ADD COLUMN IF NOT EXISTS amount_ecotax numeric
+        """
+    )
+    cr.execute(
+        """
+        UPDATE account_move SET amount_ecotax = 0.0 WHERE amount_ecotax IS NULL
+        """
+    )
+    cr.execute(
+        """
+        ALTER TABLE account_move_line ADD COLUMN IF NOT EXISTS subtotal_ecotax numeric
+        """
+    )
+    cr.execute(
+        """
+        ALTER TABLE account_move_line ADD COLUMN IF NOT EXISTS ecotax_amount_unit numeric
+        """
+    )
+    cr.execute(
+        """
+        UPDATE account_move_line
+        SET ecotax_amount_unit = 0.0, subtotal_ecotax = 0.0
+        WHERE ecotax_amount_unit IS NULL
+        """
+    )

--- a/account_ecotax_sale/__init__.py
+++ b/account_ecotax_sale/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hook import pre_init_hook

--- a/account_ecotax_sale/__manifest__.py
+++ b/account_ecotax_sale/__manifest__.py
@@ -16,4 +16,5 @@
         "security/ir.model.access.csv",
     ],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_ecotax_sale/hook.py
+++ b/account_ecotax_sale/hook.py
@@ -1,0 +1,29 @@
+def pre_init_hook(cr):
+
+    cr.execute(
+        """
+        ALTER TABLE sale_order ADD COLUMN IF NOT EXISTS amount_ecotax numeric
+        """
+    )
+    cr.execute(
+        """
+        UPDATE sale_order SET amount_ecotax = 0.0 WHERE amount_ecotax IS NULL
+        """
+    )
+    cr.execute(
+        """
+        ALTER TABLE sale_order_line ADD COLUMN IF NOT EXISTS subtotal_ecotax numeric
+        """
+    )
+    cr.execute(
+        """
+        ALTER TABLE sale_order_line ADD COLUMN IF NOT EXISTS ecotax_amount_unit numeric
+        """
+    )
+    cr.execute(
+        """
+        UPDATE sale_order_line
+        SET ecotax_amount_unit = 0.0, subtotal_ecotax = 0.0
+        WHERE ecotax_amount_unit IS NULL
+        """
+    )


### PR DESCRIPTION
Creating these computed fields could be an issue for large database, so we create it and initialize it to 0.0 to avoid this issue.