### PR TITLE
[IMP] account_product_fiscal_classification: update views by python code.

### DIFF
--- a/account_product_fiscal_classification/models/__init__.py
+++ b/account_product_fiscal_classification/models/__init__.py
@@ -1,3 +1,4 @@
+from . import product_product
 from . import product_template
 from . import account_product_fiscal_classification_template
 from . import account_product_fiscal_classification

--- a/account_product_fiscal_classification/models/product_product.py
+++ b/account_product_fiscal_classification/models/product_product.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2014-Today GRAP (http://www.grap.coop)
+# Copyright (C) 2016-Today La Louve (<http://www.lalouve.net/>)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id=view_id, view_type=view_type, **options)
+        self.env["product.template"]._alter_view_fiscal_classification(arch, view_type)
+        return arch, view

--- a/account_product_fiscal_classification/models/product_template.py
+++ b/account_product_fiscal_classification/models/product_template.py
@@ -3,10 +3,9 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import json
 import logging
 
-from lxml import etree
+from lxml import builder
 
 from odoo import api, fields, models
 
@@ -16,9 +15,9 @@ _logger = logging.getLogger(__name__)
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    taxes_id = fields.Many2many(default=False)
+    taxes_id = fields.Many2many(readonly=True, default=False)
 
-    supplier_taxes_id = fields.Many2many(default=False)
+    supplier_taxes_id = fields.Many2many(readonly=True, default=False)
 
     fiscal_classification_id = fields.Many2one(
         comodel_name="account.product.fiscal.classification",
@@ -65,20 +64,33 @@ class ProductTemplate(models.Model):
         self.taxes_id = self.fiscal_classification_id.sale_tax_ids.ids
 
     @api.model
-    def get_view(self, view_id=None, view_type="form", **options):
-        """Set fiscal_classification_id required on all views.
-        We don't set the field required by field definition to avoid
-        incompatibility with other modules, errors on import, etc..."""
-        result = super().get_view(view_id=view_id, view_type=view_type, **options)
-        doc = etree.fromstring(result["arch"])
-        nodes = doc.xpath("//field[@name='fiscal_classification_id']")
-        if nodes:
-            for node in nodes:
-                modifiers = json.loads(node.get("modifiers", "{}"))
-                modifiers["required"] = True
-                node.set("modifiers", json.dumps(modifiers))
-            result["arch"] = etree.tostring(doc, encoding="unicode").replace("\t", "")
-        return result
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id=view_id, view_type=view_type, **options)
+        self._alter_view_fiscal_classification(arch, view_type)
+        return arch, view
+
+    @api.model
+    def _alter_view_fiscal_classification(self, arch, view_type):
+        if view_type in ("form", "tree"):
+            node_taxes_id = arch.xpath("//field[@name='taxes_id']")
+            node_supplier_taxes_id = arch.xpath("//field[@name='supplier_taxes_id']")
+            node_tax_field = node_taxes_id or node_supplier_taxes_id
+            if node_tax_field:
+                # append fiscal_classification_id just before taxes fields
+                node_tax_field = node_tax_field[0]
+                classification_node = builder.E.field(
+                    name="fiscal_classification_id", required="1"
+                )
+                node_tax_field.getparent().insert(
+                    node_tax_field.getparent().index(node_tax_field),
+                    classification_node,
+                )
+
+            if view_type == "tree":
+                if node_taxes_id:
+                    node_taxes_id[0].set("optional", "hide")
+                if node_supplier_taxes_id:
+                    node_supplier_taxes_id[0].set("optional", "hide")
 
     # Custom Section
     def _fiscal_classification_update_taxes(self, vals):

--- a/account_product_fiscal_classification/views/view_product_template.xml
+++ b/account_product_fiscal_classification/views/view_product_template.xml
@@ -16,38 +16,6 @@
         </field>
     </record>
 
-    <record id="view_product_template_tree_account" model="ir.ui.view">
-        <field name="model">product.template</field>
-        <field name="inherit_id" ref="account.product_template_view_tree" />
-        <field name="arch" type="xml">
-            <field name="taxes_id" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-            <field name="supplier_taxes_id" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-            <field name="supplier_taxes_id" position="after">
-                <field name="fiscal_classification_id" />
-            </field>
-        </field>
-    </record>
-
-    <record id="view_product_template_form_account" model="ir.ui.view">
-        <field name="model">product.template</field>
-        <field name="inherit_id" ref="account.product_template_form_view" />
-        <field name="arch" type="xml">
-            <field name="taxes_id" position="before">
-                <field name="fiscal_classification_id" quick_create="false" />
-            </field>
-            <field name="taxes_id" position="attributes">
-                <attribute name="readonly">True</attribute>
-            </field>
-            <field name="supplier_taxes_id" position="attributes">
-                <attribute name="readonly">True</attribute>
-            </field>
-        </field>
-    </record>
-
     <record
         id="action_template_list_by_fiscal_classification"
         model="ir.actions.act_window"


### PR DESCRIPTION
**rational:**
In odoo, some module (like hr_expense) redefines product views. For each case, we need a glue module to insert fiscal_classification_id in the view. With that changes, insertion is done for all tree and form view.
Closes: #503, #504, #505

Also, fix : Display field also for product.produt form view.