### PR TITLE
[16.0][FIX] account_avatax_exemption_base: use _rec_name for default name

### DIFF
--- a/account_avatax_exemption_base/models/exemption.py
+++ b/account_avatax_exemption_base/models/exemption.py
@@ -76,6 +76,7 @@ class ResPartnerExemption(models.Model):
         "mail.thread",
         "mail.activity.mixin",
     ]
+    _rec_name = "partner_id"
 
     partner_id = fields.Many2one(
         "res.partner",


### PR DESCRIPTION
Having name_get method without defining a default name value causes validation error.
Name is a required field for all models.
We use _rec_name with defaulting to partner_id field.

`
2025-03-28 00:06:16,492 26588 ERROR account_avatax_exemption_document_16_2 odoo.sql_db: bad query: INSERT INTO "res_partner_exemption" ("business_type", "create_date", "create_uid", "effective_date", "exemption_number", "exemption_number_type", "exemption_type", "exemption_validity_duration", "expiry_date", "group_of_state", "partner_id", "state", "write_date", "write_uid") VALUES (1, '2025-03-28 00:06:16.482400', 2, '2025-03-28', '123', 'exemption_number/taxpayer_id', NULL, 30, '2025-03-31', NULL, 14, 'draft', '2025-03-28 00:06:16.482400', 2) RETURNING "id"
ERROR: null value in column "name" of relation "res_partner_exemption" violates not-null constraint
DETAIL:  Failing row contains (6, null, 1, null, 30, 2, 2, 14, null, null, 123, exemption_number/taxpayer_id, draft, 2025-03-28, 2025-03-31, 2025-03-28 00:06:16.4824, 2025-03-28 00:06:16.4824).
 
2025-03-28 00:06:16,531 26588 WARNING account_avatax_exemption_document_16_2 odoo.http: The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Avatax Exemption (res.partner.exemption)
Field: Exemption Name (name)

`