### PR TITLE
[17][account_ecotax,account_ecotax_sale] Add ecotax only if it match shipping address country

### DIFF
--- a/account_ecotax/models/account_ecotax_classification.py
+++ b/account_ecotax/models/account_ecotax_classification.py
@@ -82,6 +82,12 @@ class AccountEcotaxClassification(models.Model):
     )
     intrastat_code = fields.Char()
     scale_code = fields.Char()
+    country_ids = fields.Many2many(
+        "res.country",
+        string="Countries",
+        help="Ecotax will be applied when delivered in the listed countries (or all "
+        "countries if empty)",
+    )
 
     @api.depends("ecotax_type")
     def _compute_ecotax_vals(self):

--- a/account_ecotax/models/account_move_line.py
+++ b/account_ecotax/models/account_move_line.py
@@ -46,6 +46,12 @@ class AcountMoveLine(models.Model):
 
     def _get_new_vals_list(self):
         self.ensure_one()
+        if not self.product_id:
+            return []
+        country = (
+            self.move_id.partner_shipping_id.country_id
+            or self.move_id.partner_id.country_id
+        )
         new_vals_list = [
             Command.create(
                 {
@@ -53,11 +59,13 @@ class AcountMoveLine(models.Model):
                     "force_amount_unit": ecotaxline_prod.force_amount,
                 }
             )
-            for ecotaxline_prod in self.product_id.all_ecotax_line_product_ids
+            for ecotaxline_prod in self.product_id._get_country_eligible_classification(
+                country
+            )
         ]
         return new_vals_list
 
-    @api.depends("product_id")
+    @api.depends("product_id", "move_id.partner_id", "move_id.partner_shipping_id")
     def _compute_ecotax_line_ids(self):
         """Unlink and recreate ecotax_lines when modifying the product_id."""
         for line in self:

--- a/account_ecotax/models/ecotax_line_product.py
+++ b/account_ecotax/models/ecotax_line_product.py
@@ -31,6 +31,13 @@ class EcotaxLineProduct(models.Model):
         help="Ecotax Amount computed form Classification or forced ecotax amount",
         store=True,
     )
+    country_ids = fields.Many2many(
+        "res.country",
+        string="Countries",
+        related="classification_id.country_ids",
+        help="Ecotax will be applied when delivered in the listed countries (or all "
+        "countries if empty)",
+    )
     display_name = fields.Char(compute="_compute_display_name")
 
     @api.depends("classification_id", "amount")

--- a/account_ecotax/models/product_product.py
+++ b/account_ecotax/models/product_product.py
@@ -75,16 +75,34 @@ class ProductProduct(models.Model):
     )
     def _compute_product_ecotax(self):
         for product in self:
-            amount_ecotax = 0.0
-            weight_based_ecotax = 0.0
-            fixed_ecotax = 0.0
-            for ecotaxline_prod in product.all_ecotax_line_product_ids:
-                ecotax_cls = ecotaxline_prod.classification_id
-                if ecotax_cls.ecotax_type == "weight_based":
-                    weight_based_ecotax += ecotaxline_prod.amount
-                else:
-                    fixed_ecotax += ecotaxline_prod.amount
-                amount_ecotax += ecotaxline_prod.amount
+            (
+                fixed_ecotax,
+                weight_based_ecotax,
+                amount_ecotax,
+            ) = product._get_ecotax_amounts_from_classification(
+                product.all_ecotax_line_product_ids
+            )
             product.fixed_ecotax = fixed_ecotax
             product.weight_based_ecotax = weight_based_ecotax
             product.ecotax_amount = amount_ecotax
+
+    def _get_ecotax_amounts_from_classification(self, classifications):
+        self.ensure_one()
+        amount_ecotax = 0.0
+        weight_based_ecotax = 0.0
+        fixed_ecotax = 0.0
+        for ecotaxline_prod in classifications:
+            ecotax_cls = ecotaxline_prod.classification_id
+            if ecotax_cls.ecotax_type == "weight_based":
+                weight_based_ecotax += ecotaxline_prod.amount
+            else:
+                fixed_ecotax += ecotaxline_prod.amount
+            amount_ecotax += ecotaxline_prod.amount
+        return fixed_ecotax, weight_based_ecotax, amount_ecotax
+
+    def _get_country_eligible_classification(self, country):
+        self.ensure_one()
+        return self.all_ecotax_line_product_ids.filtered(
+            lambda line: not line.country_ids
+            or (country and country in line.country_ids)
+        )

--- a/account_ecotax/tests/test_ecotax.py
+++ b/account_ecotax/tests/test_ecotax.py
@@ -407,6 +407,33 @@ class TestInvoiceEcotaxCommon(BaseCommon):
             variant_2.product_tmpl_id.ecotax_line_product_ids,
         )
 
+    def _test_06_ecotax_by_country(self):
+        """
+        Test default ecotax by country
+        """
+        self.invoice_partner.write({"country_id": self.env.ref("base.fr").id})
+        invoice = self._make_invoice(products=self._make_product(self.ecotax_fixed))
+        # no country ecotax classification is set
+        self.assertEqual(
+            invoice.invoice_line_ids.ecotax_line_ids.classification_id,
+            self.ecotax_fixed,
+        )
+        # in case of wrong country, the ecotax is not set
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.de").id)]}
+        )
+        invoice.write({"partner_id": self.invoice_partner.id})
+        self.assertFalse(invoice.invoice_line_ids.ecotax_line_ids.classification_id)
+        # in case the same country is set, the ecotax is set as well
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.fr").id)]}
+        )
+        invoice.write({"partner_id": self.invoice_partner.id})
+        self.assertEqual(
+            invoice.invoice_line_ids.ecotax_line_ids.classification_id,
+            self.ecotax_fixed,
+        )
+
 
 class TestInvoiceEcotax(TestInvoiceEcotaxCommon):
     def test_01_default_fixed_ecotax(self):
@@ -423,3 +450,6 @@ class TestInvoiceEcotax(TestInvoiceEcotaxCommon):
 
     def test_05_product_variants(self):
         self._test_05_product_variants()
+
+    def test_06_ecotax_by_country(self):
+        self._test_06_ecotax_by_country()

--- a/account_ecotax/views/account_ecotax_classification_view.xml
+++ b/account_ecotax/views/account_ecotax_classification_view.xml
@@ -14,6 +14,7 @@
                 <field name="ecotax_type" />
                 <field name="categ_id" />
                 <field name="product_status" />
+                <field name="country_ids" widget="many2many_tags" optional="hide" />
             </tree>
         </field>
     </record>
@@ -50,6 +51,7 @@
                     </group>
                     <separator string="Ecotaxes settings" />
                     <group col="4" name="ecotax_settings">
+                        <field name="country_ids" widget="many2many_tags" />
                         <field name="ecotax_type" />
                         <field
                             name="ecotax_coef"

--- a/account_ecotax/views/product_template_view.xml
+++ b/account_ecotax/views/product_template_view.xml
@@ -22,6 +22,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </tree>
                         </field>
                     </div>

--- a/account_ecotax/views/product_view.xml
+++ b/account_ecotax/views/product_view.xml
@@ -26,6 +26,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </tree>
                         </field>
                     </div>
@@ -43,6 +44,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </tree>
                         </field>
                     </div>
@@ -73,6 +75,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </tree>
                         </field>
                     </div>

--- a/account_ecotax_sale/models/sale_order_line.py
+++ b/account_ecotax_sale/models/sale_order_line.py
@@ -48,6 +48,12 @@ class SaleOrderLine(models.Model):
 
     def _get_new_vals_list(self):
         self.ensure_one()
+        if not self.product_id:
+            return []
+        country = (
+            self.order_id.partner_shipping_id.country_id
+            or self.order_id.partner_id.country_id
+        )
         new_vals_list = [
             Command.create(
                 {
@@ -55,11 +61,13 @@ class SaleOrderLine(models.Model):
                     "force_amount_unit": ecotaxline_prod.force_amount,
                 }
             )
-            for ecotaxline_prod in self.product_id.all_ecotax_line_product_ids
+            for ecotaxline_prod in self.product_id._get_country_eligible_classification(
+                country
+            )
         ]
         return new_vals_list
 
-    @api.depends("product_id")
+    @api.depends("product_id", "order_id.partner_id", "order_id.partner_shipping_id")
     def _compute_ecotax_line_ids(self):
         """Unlink and recreate ecotax_lines when modifying the product_id."""
         for line in self:

--- a/account_ecotax_sale/tests/test_sale_ecotax.py
+++ b/account_ecotax_sale/tests/test_sale_ecotax.py
@@ -2,6 +2,7 @@
 #   @author Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import Command
 from odoo.tests.common import Form
 
 from odoo.addons.account_ecotax.tests.test_ecotax import TestInvoiceEcotaxCommon
@@ -49,15 +50,15 @@ class TestsaleEcotaxCommon(TestInvoiceEcotaxCommon):
         ]
 
     def create_sale_partner(self, partner_id, products_and_qty):
-        sale_form = Form(self.env["sale.order"])
-        sale_form.partner_id = partner_id
-
-        for product, qty in products_and_qty:
-            with sale_form.order_line.new() as line_form:
-                line_form.product_id = product
-                line_form.product_uom_qty = qty
-
-        sale = sale_form.save()
+        sale = self.env["sale.order"].create(
+            {
+                "partner_id": partner_id.id,
+                "order_line": [
+                    Command.create({"product_id": product.id, "product_uom_qty": qty})
+                    for product, qty in products_and_qty
+                ],
+            }
+        )
 
         return sale
 
@@ -107,6 +108,34 @@ class TestsaleEcotaxCommon(TestInvoiceEcotaxCommon):
         self.assertEqual(self.sale.amount_untaxed, 1000.0)
         self.assertEqual(self.sale.amount_ecotax, 47.0)
 
+    def _test_03_ecotax_by_country(self):
+        """
+        Test default ecotax by country
+        """
+        partner12 = self.env.ref("base.res_partner_12")
+        partner12.write({"country_id": self.env.ref("base.fr").id})
+        sale = self.create_sale_partner(
+            partner_id=partner12, products_and_qty=[(self.product_a, 1.0)]
+        )
+        # no country ecotax classification is set, ecotax is taken by default
+        self.assertEqual(
+            sale.order_line.ecotax_line_ids.classification_id, self.ecotax_fixed
+        )
+        # in case of wrong country, the ecotax is not set
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.de").id)]}
+        )
+        sale.write({"partner_id": partner12.id})
+        self.assertFalse(sale.order_line.ecotax_line_ids.classification_id)
+        # in case the same country is set, the ecotax is set as well
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.fr").id)]}
+        )
+        sale.write({"partner_id": sale.partner_id.id})
+        self.assertEqual(
+            sale.order_line.ecotax_line_ids.classification_id, self.ecotax_fixed
+        )
+
 
 class TestsaleEcotax(TestsaleEcotaxCommon):
     def test_01_classification_weight_based_ecotax(self):
@@ -114,3 +143,6 @@ class TestsaleEcotax(TestsaleEcotaxCommon):
 
     def test_02_classification_ecotax(self):
         self._test_02_classification_ecotax()
+
+    def test_03_ecotax_by_country(self):
+        self._test_03_ecotax_by_country()


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-fiscal-rule/pull/501

This does not change the current behavior when installed because if you do not configure any country on the classification, it still applies for every country.

Maybe it could interest you @vvrossem @SilvioC2C 