### PR TITLE
[17.0][FIX] account_fiscal_position_partner_type: make fiscal_position_type field visible

### DIFF
--- a/account_fiscal_position_partner_type/README.rst
+++ b/account_fiscal_position_partner_type/README.rst
@@ -43,9 +43,9 @@ Configuration
 User can configure the default value according to the system company
 going to:
 
--  Settings/Users & Companies/Companies.
--  Changing the value of the "Default Partner Fiscal Position Type"
-   field.
+- Settings/Users & Companies/Companies.
+- Changing the value of the "Default Partner Fiscal Position Type"
+  field.
 
 Usage
 =====
@@ -54,8 +54,8 @@ Create a new partner and define the "Fiscal Position Type" field.
 
 Create a new Fiscal Position, with the following configuration:
 
--  'Detect Automatically' -> checked.
--  'Fiscal Position Type'
+- 'Detect Automatically' -> checked.
+- 'Fiscal Position Type'
 
 Create a new Sale/Invoice and select the partner. Remember that the
 system recalculates the fiscal position according to the shipping
@@ -82,18 +82,19 @@ Authors
 Contributors
 ------------
 
--  `Sygel <https://www.sygel.es>`__:
+- `Sygel <https://www.sygel.es>`__:
 
-      -  Harald Panten
-      -  Valentin Vinagre
+     - Harald Panten
+     - Valentin Vinagre
+     - Juan Alberto Raja Martinez
 
--  `Tecnativa <https://www.tecnativa.com>`__:
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-      -  Pedro M. Baeza
+     - Pedro M. Baeza
 
--  Open Source Integrators (https://opensourceintegrators.com)
+- Open Source Integrators (https://opensourceintegrators.com)
 
-   -  Nikul Chaudhary <nchaudhary@opensourceintegrators.com>
+  - Nikul Chaudhary <nchaudhary@opensourceintegrators.com>
 
 Maintainers
 -----------

--- a/account_fiscal_position_partner_type/readme/CONTRIBUTORS.md
+++ b/account_fiscal_position_partner_type/readme/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
   > - Harald Panten
   > - Valentin Vinagre
+  > - Juan Alberto Raja Martinez
 
 - [Tecnativa](https://www.tecnativa.com):
 

--- a/account_fiscal_position_partner_type/static/description/index.html
+++ b/account_fiscal_position_partner_type/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -432,6 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Harald Panten</li>
 <li>Valentin Vinagre</li>
+<li>Juan Alberto Raja Martinez</li>
 </ul>
 </blockquote>
 </li>
@@ -452,7 +454,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_fiscal_position_partner_type/views/res_partner.xml
+++ b/account_fiscal_position_partner_type/views/res_partner.xml
@@ -9,7 +9,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='vat']" position="before">
+            <xpath expr="//field[@name='vat']/.." position="after">
                 <field name="fiscal_position_type" invisible="parent_id != False" />
             </xpath>
         </field>


### PR DESCRIPTION
@HaraldPanten @luis-ron @ValentinVinagre @manuelregidor 
In Odoo 17.0, the fiscal_position_type field added by the account_fiscal_position_partner_type module is not properly displayed in the partner form. Its label overlaps with the VAT field, making it invisible or partially hidden.

This fix adjusts the XML view definition to ensure the fiscal_position_type field label is correctly rendered and not overlapped by other fields.

We originally tried placing the fiscal_position_type field with: <xpath expr="//field[@name='vat']" position="before">

However, this caused layout issues due to the positioning of the VAT field and compatibility problems with the base_vat module.To resolve this, we changed the XPath to:
<xpath expr="//field[@name='vat']/.." position="after">

This ensures proper rendering of the field in the partner form view without relying on base_vat, depending only on the account module. 


T-7834
