### PR TITLE
[16.0][FIX] account_fiscal_position_partner_type: Post-install test + fallback to load CoA

### DIFF
--- a/account_fiscal_position_partner_type/tests/test_account_fiscal_position_partner_type.py
+++ b/account_fiscal_position_partner_type/tests/test_account_fiscal_position_partner_type.py
@@ -2,13 +2,23 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields
-from odoo.tests import Form, common
+from odoo.tests import Form, common, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestAccountFiscalPositionPartnerType(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         # MODELS
         cls.res_partner_model = cls.env["res.partner"]
         cls.fiscal_position_model = cls.env["account.fiscal.position"]
@@ -17,6 +27,7 @@ class TestAccountFiscalPositionPartnerType(common.TransactionCase):
         cls.company_main = cls.env.ref("base.main_company")
         cls.company_main.default_fiscal_position_type = "b2b"
         # Fiscal Positions
+        cls.fiscal_position_model.search([]).unlink()
         cls.fiscal_position_test = cls.fiscal_position_model.create(
             {
                 "name": "Test",


### PR DESCRIPTION

Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa