### PR TITLE
[17.0] [IMP] l10n_eu_oss_oca: Slovakia 2025 VAT

### DIFF
--- a/l10n_eu_oss_oca/data/oss.tax.rate.csv
+++ b/l10n_eu_oss_oca/data/oss.tax.rate.csv
@@ -22,7 +22,7 @@ oss_eu_rate_nl,base.nl,21,9,0,0
 oss_eu_rate_pl,base.pl,23,8,5,0
 oss_eu_rate_pt,base.pt,23,13,6,0
 oss_eu_rate_ro,base.ro,19,9,5,0
-oss_eu_rate_sk,base.sk,20,10,0,0
+oss_eu_rate_sk,base.sk,23,10,0,0
 oss_eu_rate_si,base.si,22,9.5,5,0
 oss_eu_rate_es,base.es,21,10,4,0
 oss_eu_rate_se,base.se,25,12,6,0


### PR DESCRIPTION
Slovakia change of general VAT rate. From 20% to 23%, effective on January 2025