### PR TITLE
[18.0][FIX] account_fiscal_position_partner_type: fiscal_position_type field position

### DIFF
--- a/account_fiscal_position_partner_type/views/res_partner.xml
+++ b/account_fiscal_position_partner_type/views/res_partner.xml
@@ -7,9 +7,9 @@
     <record id="view_partner_form_fiscal_position_type" model="ir.ui.view">
         <field name="name">view.partner.form.fiscal.position.type</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="inherit_id" ref="account.partner_view_buttons" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='vat']" position="before">
+            <xpath expr="//field[@name='partner_vat_placeholder']" position="before">
                 <field name="fiscal_position_type" invisible="parent_id != False" />
             </xpath>
         </field>


### PR DESCRIPTION
This PR fixes the position of the `fiscal_position_type` field in the `res.partner` form view, that was originally incorrect if the module `base_vat` was installed. Some screenshots to explain this situation, see the **Fiscal Position Type** field:

**Before this fix:**

<img width="1368" height="764" alt="image" src="https://github.com/user-attachments/assets/e13fc62c-00bf-4944-909f-43e55a2ca4b5" />

<img width="1354" height="737" alt="image" src="https://github.com/user-attachments/assets/58851a02-5339-4d97-8a38-c0793c142557" />

**After this fix:**

<img width="1354" height="716" alt="image" src="https://github.com/user-attachments/assets/367eb9cb-b6a0-456f-8dfa-c7625fe0fbdf" />

<img width="1364" height="766" alt="image" src="https://github.com/user-attachments/assets/b375df3d-238c-49e3-a8f9-a1334d4668af" />