### PR TITLE
[16] Fix build fixing account_ecotax_tax tests

### DIFF
--- a/account_ecotax/tests/test_ecotax.py
+++ b/account_ecotax/tests/test_ecotax.py
@@ -203,8 +203,8 @@ class TestInvoiceEcotaxCommon(TransactionCase):
         return new_qtys
 
     def _run_checks(self, inv, inv_expected_amounts, inv_lines_expected_amounts):
-        self.assertEqual(inv.amount_ecotax, inv_expected_amounts["amount_ecotax"])
-        self.assertEqual(inv.amount_total, inv_expected_amounts["amount_total"])
+        self.assertAlmostEqual(inv.amount_ecotax, inv_expected_amounts["amount_ecotax"])
+        self.assertAlmostEqual(inv.amount_total, inv_expected_amounts["amount_total"])
         self.assertEqual(len(inv.invoice_line_ids), len(inv_lines_expected_amounts))
         for inv_line, inv_line_expected_amounts in zip(
             inv.invoice_line_ids, inv_lines_expected_amounts

--- a/account_ecotax_sale_tax/tests/test_sale_ecotax.py
+++ b/account_ecotax_sale_tax/tests/test_sale_ecotax.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
+from odoo.tests.common import Form
+
 from odoo.addons.account_ecotax_sale.tests.test_sale_ecotax import TestsaleEcotaxCommon
 from odoo.addons.account_ecotax_tax.tests.test_ecotax import TestInvoiceEcotaxTaxComon
 
@@ -13,7 +15,46 @@ class TestsaleEcotaxTax(TestInvoiceEcotaxTaxComon, TestsaleEcotaxCommon):
         super().setUpClass()
 
     def test_01_classification_weight_based_ecotax(self):
-        self._test_01_classification_weight_based_ecotax()
+        """Tests  with weight based ecotaxs"""
+        # in order to test the correct assignment of weight ecotax
+        # I create a customer sale.
+        partner12 = self.env.ref("base.res_partner_12")
+        self.sale = self.create_sale_partner(
+            partner_id=partner12, products_and_qty=[(self.product_b, 1.0)]
+        )
+        self.assertEqual(self.product_b.ecotax_amount, 16)
+        so_form = Form(self.sale)
+        with so_form.order_line.edit(0) as line:
+            line.product_uom_qty = 3.0
+        so_form.save()
+        self.assertEqual(self.sale.order_line.ecotax_amount_unit, 16)
+        self.assertEqual(self.sale.order_line.subtotal_ecotax, 48)
+        self.assertEqual(self.sale.amount_total, 648)
+        self.assertEqual(self.sale.amount_ecotax, 48)
 
     def test_02_classification_ecotax(self):
-        self._test_02_classification_ecotax()
+        """Tests multiple lines with mixed ecotaxs"""
+        # in order to test the correct assignment of fixed ecotax and weight ecotax
+        # I create a customer sale.
+        partner12 = self.env.ref("base.res_partner_12")
+        self.sale = self.create_sale_partner(
+            partner_id=partner12,
+            products_and_qty=[(self.product_a, 1.0), (self.product_b, 2.0)],
+        )
+        # I assign a product with fixed ecotaxte to sale line
+        sale_line1 = self.sale.order_line[0]
+        # make sure to have 1 tax and fix tax rate
+        sale_line2 = self.sale.order_line[1]
+        # make sure to have 1 tax and fix tax rate
+        self.assertEqual(self.product_a.ecotax_amount, 5.0)
+        so_form = Form(self.sale)
+        with so_form.order_line.edit(0) as line:
+            line.product_uom_qty = 3.0
+        so_form.save()
+
+        self.assertEqual(sale_line1.ecotax_amount_unit, 5.0)
+        self.assertAlmostEqual(sale_line1.subtotal_ecotax, 15.0)
+        self.assertEqual(sale_line2.ecotax_amount_unit, 16)
+        self.assertEqual(sale_line2.subtotal_ecotax, 32)
+        self.assertEqual(self.sale.amount_total, 1047.0)
+        self.assertEqual(self.sale.amount_ecotax, 47.0)

--- a/account_ecotax_tax/README.rst
+++ b/account_ecotax_tax/README.rst
@@ -79,6 +79,12 @@ Usage
 
    - The ecotax amount can also be manually overridden on the product.
 
+Known issues / Roadmap
+======================
+
+Since an update in Odoo https://github.com/odoo/odoo/commit/13e9833e0bc809a26843890363586f61a37d061c the case with ecotax as tax included and another tax included does not work anymore.
+The ecotax tax should only be used along with price excluded tax, or be configured as price excluded itself.
+
 Bug Tracker
 ===========
 

--- a/account_ecotax_tax/readme/ROADMAP.rst
+++ b/account_ecotax_tax/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+Since an update in Odoo https://github.com/odoo/odoo/commit/13e9833e0bc809a26843890363586f61a37d061c the case with ecotax as tax included and another tax included does not work anymore.
+The ecotax tax should only be used along with price excluded tax, or be configured as price excluded itself.

--- a/account_ecotax_tax/static/description/index.html
+++ b/account_ecotax_tax/static/description/index.html
@@ -379,11 +379,12 @@ The advantages compared to the base account_ecotax module is that it allows to :
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -434,8 +435,13 @@ The advantages compared to the base account_ecotax module is that it allows to :
 </li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<p>Since an update in Odoo <a class="reference external" href="https://github.com/odoo/odoo/commit/13e9833e0bc809a26843890363586f61a37d061c">https://github.com/odoo/odoo/commit/13e9833e0bc809a26843890363586f61a37d061c</a> the case with ecotax as tax included and another tax included does not work anymore.
+The ecotax tax should only be used along with price excluded tax, or be configured as price excluded itself.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-fiscal-rule/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -443,22 +449,22 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Mourad EL HADJ MIMOUNE &lt;<a class="reference external" href="mailto:mourad.elhadj.mimoune&#64;akretion.com">mourad.elhadj.mimoune&#64;akretion.com</a>&gt;</li>
 <li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/account_ecotax_tax/tests/test_ecotax.py
+++ b/account_ecotax_tax/tests/test_ecotax.py
@@ -11,6 +11,11 @@ class TestInvoiceEcotaxTaxComon(TestInvoiceEcotaxCommon):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
         # ACCOUNTING STUFF
+        # Main use case for using ecotax with tax is to manage the ecotax as not
+        # included with tax not included (B2B case)
+        # Also for this version, the included use case using tax is broken because
+        # of a bug in Odoo core (check readme)
+        cls.invoice_tax.price_include = False
         cls.invoice_ecotax_account = cls.env["account.account"].create(
             {
                 "code": "707120",
@@ -24,7 +29,7 @@ class TestInvoiceEcotaxTaxComon(TestInvoiceEcotaxCommon):
                 "name": "Fixed Ecotax",
                 "type_tax_use": "sale",
                 "company_id": cls.env.user.company_id.id,
-                "price_include": True,
+                "price_include": False,
                 "amount_type": "code",
                 "include_base_amount": True,
                 "sequence": 0,
@@ -79,7 +84,7 @@ class TestInvoiceEcotaxTaxComon(TestInvoiceEcotaxCommon):
                 "company_id": cls.env.user.company_id.id,
                 "amount_type": "code",
                 "include_base_amount": True,
-                "price_include": True,
+                "price_include": False,
                 "sequence": 0,
                 "is_ecotax": True,
                 "python_compute": "result = (quantity and"
@@ -134,16 +139,191 @@ class TestInvoiceEcotaxTaxComon(TestInvoiceEcotaxCommon):
 
 class TestInvoiceEcotaxTax(TestInvoiceEcotaxTaxComon):
     def test_01_default_fixed_ecotax(self):
-        self._test_01_default_fixed_ecotax()
+        """Test default fixed ecotax
+
+        Ecotax classification data for this test:
+            - fixed type
+            - default amount: 5.0
+        Product data for this test:
+            - list price: 100
+            - fixed ecotax
+            - no manual amount
+
+        Expected results (with 1 line and qty = 1):
+            - invoice ecotax amount: 5.0
+            - invoice total amount: 115.5
+            - line ecotax unit amount: 5.0
+            - line ecotax total amount: 5.0
+        """
+        invoice = self._make_invoice(products=self._make_product(self.ecotax_fixed))
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 5.0, "amount_total": 115.5},
+            [{"ecotax_amount_unit": 5.0, "subtotal_ecotax": 5.0}],
+        )
+        new_qty = self._set_invoice_lines_random_quantities(invoice)[0]
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 5.0 * new_qty, "amount_total": 115.5 * new_qty},
+            [{"ecotax_amount_unit": 5.0, "subtotal_ecotax": 5.0 * new_qty}],
+        )
 
     def test_02_force_fixed_ecotax_on_product(self):
-        self._test_02_force_fixed_ecotax_on_product()
+        """Test manual fixed ecotax
+
+        Ecotax classification data for this test:
+            - fixed type
+            - default amount: 5.0
+        Product data for this test:
+            - list price: 100
+            - fixed ecotax
+            - Force ecotax amount: 10
+
+        Expected results (with 1 line and qty = 1):
+            - invoice ecotax amount: 10.0
+            - invoice total amount: 121.0
+            - line ecotax unit amount: 10.0
+            - line ecotax total amount: 10.0
+        """
+        product = self._make_product(self.ecotax_fixed)
+        product.ecotax_line_product_ids[0].force_amount = 10
+        invoice = self._make_invoice(products=product)
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 10.0, "amount_total": 121.0},
+            [{"ecotax_amount_unit": 10.0, "subtotal_ecotax": 10.0}],
+        )
+        new_qty = self._set_invoice_lines_random_quantities(invoice)[0]
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 10.0 * new_qty, "amount_total": 121.0 * new_qty},
+            [{"ecotax_amount_unit": 10.0, "subtotal_ecotax": 10.0 * new_qty}],
+        )
 
     def test_03_weight_based_ecotax(self):
-        self._test_03_weight_based_ecotax()
+        """Test weight based ecotax
+
+        Ecotax classification data for this test:
+            - weight based type
+            - coefficient: 0.04
+        Product data for this test:
+            - list price: 100
+            - weight based ecotax
+            - weight: 100
+
+        Expected results (with 1 line and qty = 1):
+            - invoice ecotax amount: 4.0
+            - invoice total amount: 114.4
+            - line ecotax unit amount: 4.0
+            - line ecotax total amount: 4.0
+        """
+        invoice = self._make_invoice(products=self._make_product(self.ecotax_weight))
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 4.0, "amount_total": 114.4},
+            [{"ecotax_amount_unit": 4.0, "subtotal_ecotax": 4.0}],
+        )
+        new_qty = self._set_invoice_lines_random_quantities(invoice)[0]
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 4.0 * new_qty, "amount_total": 114.4 * new_qty},
+            [{"ecotax_amount_unit": 4.0, "subtotal_ecotax": 4.0 * new_qty}],
+        )
 
     def test_04_mixed_ecotax(self):
-        self._test_04_mixed_ecotax()
+        """Test mixed ecotax within the same invoice
+
+        Creating an invoice with 3 lines (one per type with types tested above)
+
+        Expected results (with 3 lines and qty = 1):
+            - invoice ecotax amount: 19.0
+            - invoice total amount: 350.9
+            - line ecotax unit amount (fixed ecotax): 5.0
+            - line ecotax total amount (fixed ecotax): 5.0
+            - line ecotax unit amount (manual ecotax): 10.0
+            - line ecotax total amount (manual ecotax): 10.0
+            - line ecotax unit amount (weight based ecotax): 4.0
+            - line ecotax total amount (weight based ecotax): 4.0
+        """
+        default_fixed_product = self._make_product(self.ecotax_fixed)
+        manual_fixed_product = self._make_product(self.ecotax_fixed)
+        manual_fixed_product.ecotax_line_product_ids[0].force_amount = 10
+        weight_based_product = self._make_product(self.ecotax_weight)
+        invoice = self._make_invoice(
+            products=default_fixed_product | manual_fixed_product | weight_based_product
+        )
+        self._run_checks(
+            invoice,
+            {"amount_ecotax": 19.0, "amount_total": 350.9},
+            [
+                {"ecotax_amount_unit": 5.0, "subtotal_ecotax": 5.0},
+                {"ecotax_amount_unit": 10.0, "subtotal_ecotax": 10.0},
+                {"ecotax_amount_unit": 4.0, "subtotal_ecotax": 4.0},
+            ],
+        )
+        new_qtys = self._set_invoice_lines_random_quantities(invoice)
+        self._run_checks(
+            invoice,
+            {
+                "amount_ecotax": 5.0 * new_qtys[0]
+                + 10.0 * new_qtys[1]
+                + 4.0 * new_qtys[2],
+                "amount_total": 115.5 * new_qtys[0]
+                + 121.0 * new_qtys[1]
+                + 114.4 * new_qtys[2],
+            },
+            [
+                {"ecotax_amount_unit": 5.0, "subtotal_ecotax": 5.0 * new_qtys[0]},
+                {"ecotax_amount_unit": 10.0, "subtotal_ecotax": 10.0 * new_qtys[1]},
+                {"ecotax_amount_unit": 4.0, "subtotal_ecotax": 4.0 * new_qtys[2]},
+            ],
+        )
 
     def test_05_product_variants(self):
-        self._test_05_product_variants()
+        """
+        Data:
+            A product template with two variants
+        Test Case:
+            Add additional ecotax line to one variant
+        Expected result:
+            The additional ecotax line is not associated  to second variant
+            the all ecotax lines of the variant contains both the ecotax
+            line of the product template and the additional ecotax line
+        """
+        variants = self._make_product_variants(self.ecotax_fixed)
+        self.assertEqual(len(variants), 2)
+        variant_1 = variants[0]
+        variant_2 = variants[1]
+        self.assertEqual(
+            variant_1.all_ecotax_line_product_ids,
+            variant_2.all_ecotax_line_product_ids,
+        )
+        variant_1.additional_ecotax_line_product_ids = [
+            (
+                0,
+                0,
+                {
+                    "classification_id": self.ecotax_weight.id,
+                },
+            )
+        ]
+        all_additional_ecotax = (
+            variant_1.additional_ecotax_line_product_ids
+            | variant_1.product_tmpl_id.ecotax_line_product_ids
+        )
+        self.assertEqual(
+            len(variant_1.all_ecotax_line_product_ids),
+            2,
+        )
+        self.assertEqual(
+            len(variant_2.all_ecotax_line_product_ids),
+            1,
+        )
+        self.assertEqual(
+            variant_1.all_ecotax_line_product_ids,
+            all_additional_ecotax,
+        )
+        self.assertEqual(
+            variant_2.all_ecotax_line_product_ids,
+            variant_2.product_tmpl_id.ecotax_line_product_ids,
+        )


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/13e9833e0bc809a26843890363586f61a37d061c
it seems that having a python code tax with included price option along with another included price option tax that take the first tax into account does not work anymore.

In order to make the CI green again, I did change the test of the module account_tax_ecotax in order to test with price excluded taxes and avoid the issue, at least in the tests.
From what I saw, we do not need this account_ecotax_tax module for the price included tax case, the module is mainly usefull to have price excluded ecotax management.
Also the but does not seem to happen in Odoo 18, so I think the problematic case won't really be an issue in v16 and won't be for further versions.

This PR does NOT need to be ported in following versions nor need to be taken into account in the migration of this module. (although it is not really an issue if it is)