### PR TITLE
[14.0] [FIX] account_product_fiscal_classification: Multi company fixes

### DIFF
--- a/account_product_fiscal_classification/models/account_product_fiscal_classification.py
+++ b/account_product_fiscal_classification/models/account_product_fiscal_classification.py
@@ -116,7 +116,7 @@ class AccountProductFiscalClassification(models.Model):
 
         for fc in fcs:
             if (
-                fc.company_id.id == company_id
+                (not fc.company_id or fc.company_id.id == company_id)
                 and sorted(fc.sale_tax_ids.ids) == sorted(sale_tax_ids)
                 and sorted(fc.purchase_tax_ids.ids) == sorted(purchase_tax_ids)
             ):

--- a/account_product_fiscal_classification/security/ir_rule.xml
+++ b/account_product_fiscal_classification/security/ir_rule.xml
@@ -11,6 +11,6 @@
         <field name="global" eval="True" />
         <field
             name="domain_force"
-        >['|', ('company_id', '=', user.company_id.id), ('company_id', '=', False)]</field>
+        >['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 </odoo>


### PR DESCRIPTION
The `ir.rule` is wrong and should use `company_ids` (which is the case in the 16.0 version). 

Also a classification without company should be instance wide.