### PR TITLE
[17.0][FIX] l10n_eu_oss_oca: set country on tax groups

### DIFF
--- a/l10n_eu_oss_oca/migrations/17.0.1.0.0/post-migration.py
+++ b/l10n_eu_oss_oca/migrations/17.0.1.0.0/post-migration.py
@@ -8,5 +8,8 @@ def migrate(cr, version):
         return
     env = api.Environment(cr, SUPERUSER_ID, {})
     oss_taxes = env["account.tax"].search([("oss_country_id", "!=", False)])
+    oss_tax_groups = oss_taxes.mapped("tax_group_id")
+    for oss_tax_group in oss_tax_groups:
+        oss_tax_group.country_id = oss_tax_group.company_id.account_fiscal_country_id
     for oss_tax in oss_taxes:
         oss_tax.country_id = oss_tax.company_id.account_fiscal_country_id

--- a/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
+++ b/l10n_eu_oss_oca/wizard/l10n_eu_oss_wizard.py
@@ -92,7 +92,10 @@ class L10nEuOssWizard(models.TransientModel):
     )
 
     def _prepare_tax_group_vals(self, rate):
-        return {"name": _("OSS VAT %s%%") % rate}
+        return {
+            "name": _("OSS VAT %s%%") % rate,
+            "country_id": self.company_id.account_fiscal_country_id.id,
+        }
 
     def _prepare_repartition_line_vals(self, original_rep_lines):
         return [


### PR DESCRIPTION
This fix sets `country_id` for all the OSS tax groups, upon creation as well as on the migration script. This avoids the `tax_group_id` from being changed and set incorrectly by [this method](https://github.com/odoo/odoo/blob/eee013201da79716fedaee5185e6dbebb046ab52/addons/account/models/account_tax.py#L222) on OSS taxes when changing the `country_id` in the migration script.

Without this change, when modifying the `country_id` of the OSS taxes, their tax group would be recomputed and it could be assigned to a wrong group (not even related to OSS).