### PR TITLE
[16.0][FIX] account_avatax_oca: make appname and version editable

### DIFF
--- a/account_avatax_oca/__manifest__.py
+++ b/account_avatax_oca/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Avalara Avatax Certified Connector",
-    "version": "16.0.1.7.0",
+    "version": "16.0.1.7.1",
     "author": "Open Source Integrators, Fabrice Henrion,"
     "Sodexis, Odoo Community Association (OCA)",
     "summary": "Compute Sales Tax using the Avalara Avatax Service",

--- a/account_avatax_oca/migrations/16.0.1.7.1/pre-migration.py
+++ b/account_avatax_oca/migrations/16.0.1.7.1/pre-migration.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2025 Kencove - Mohamed Alkobrosli
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+from datetime import datetime
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+def add_avatax_app_fields(env):
+    """Add 'appname' and 'version' columns if missing."""
+    openupgrade.add_fields(
+        env,
+        [
+            (
+                "appname",  # field name
+                "avalara.salestax",  # model name
+                "avalara_salestax",  # table name
+                "char",  # odoo field type
+                False,  # SQL type override
+                "account_avatax_oca",  # module name
+                False,  # default value
+            ),
+            (
+                "version",
+                "avalara.salestax",
+                "avalara_salestax",
+                "char",
+                False,
+                "account_avatax_oca",
+                False,
+            ),
+        ],
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Migration entry point for version 16.0.1.7.1"""
+    add_avatax_app_fields(env)
+    today_str = datetime.today().strftime("%Y%m%d")
+    env.cr.execute(
+        """
+        UPDATE avalara_salestax
+        SET appname = COALESCE(appname, %s),
+            version = COALESCE(version, %s)
+    """,
+        (env.company.name, today_str),
+    )
+    _logger.info("======================================")
+    _logger.info("Setting appname and version fields")
+    _logger.info("======================================")

--- a/account_avatax_oca/models/avalara_salestax.py
+++ b/account_avatax_oca/models/avalara_salestax.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -118,6 +119,16 @@ class AvalaraSalestax(models.Model):
         required=True,
         default=lambda self: self.env.company,
         help="Company which has subscribed to the AvaTax service",
+    )
+    appname = fields.Char(
+        string="AvaTax Application Name",
+        default=lambda self: self.env.company.name,
+        help="Name reported to Avalara when connecting through the API.",
+    )
+    version = fields.Char(
+        string="AvaTax Application Version",
+        default=lambda self: datetime.today().strftime("%Y%m%d"),
+        help="Version reported to Avalara when connecting through the API.",
     )
     company_partner_id = fields.Many2one(
         string="Company Address",

--- a/account_avatax_oca/models/avatax_rest_api.py
+++ b/account_avatax_oca/models/avatax_rest_api.py
@@ -29,8 +29,10 @@ class AvaTaxRESTService:
         self.timeout = not config and timeout or config.request_timeout
         self.is_log_enabled = enable_log or config and config.logging
         # Set elements adapter defaults
-        self.appname = "Odoo 15 - Open Source Integrators/OCA"
-        self.version = "a0o5a000007SPdsAAG"
+        self.appname = (
+            config and config.appname
+        ) or "Odoo 15 - Open Source Integrators/OCA"
+        self.version = (config and config.version) or "a0o5a000007SPdsAAG"
         self.hostname = socket.gethostname()
         url = url or (config and config.service_url) or ""
         self.environment = (

--- a/account_avatax_oca/views/avalara_salestax_view.xml
+++ b/account_avatax_oca/views/avalara_salestax_view.xml
@@ -15,6 +15,8 @@
                                 name="company_id"
                                 options="{'no_create_edit': True}"
                             />
+                            <field name="appname" />
+                            <field name="version" />
                         </group>
                         <group>
                             <field name="company_partner_id" />


### PR DESCRIPTION
Keeping the defaults is making someone be costed money, better to have the appname my company.