### PR TITLE
[18.0][FIX] account_ecotax: order of field in account.report_invoice_document

### DIFF
--- a/account_ecotax/report/invoice.xml
+++ b/account_ecotax/report/invoice.xml
@@ -5,7 +5,7 @@
         inherit_id="account.report_invoice_document"
         priority="100"
     >
-        <xpath expr="//th[@name='th_priceunit']" position="after">
+        <th name="th_priceunit" position="after">
             <th
                 name="th_ecotax"
                 t-if="o.amount_ecotax"
@@ -13,15 +13,15 @@
             >
                 <span name="ecotax_line_label">Eco Part Unit</span>
             </th>
-        </xpath>
-        <xpath expr="//td[span[@t-field='line.discount']]" position="after">
+        </th>
+        <td name="td_price_unit" position="after">
             <td
                 t-if="o.amount_ecotax"
                 t-attf-class="text-center {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
             >
                 <span class="text-nowrap" t-field="line.ecotax_amount_unit" />
             </td>
-        </xpath>
+        </td>
     </template>
 
     <template


### PR DESCRIPTION
<img width="973" height="141" alt="account_invoice" src="https://github.com/user-attachments/assets/1625e0de-3ad5-432f-8b0d-d9a1f2004374" />
In this screen the discount is 50 and the ecotax is 0.3 the order in the header and the body is reversed.

This PR fixes that