### PR TITLE
[IMP] account_fiscal_position_vies_warning: added condition for show vies warning

### DIFF
--- a/account_fiscal_position_vies_warning/models/account_fiscal_position.py
+++ b/account_fiscal_position_vies_warning/models/account_fiscal_position.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Moduon Team S.L. <info@moduon.team>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -20,6 +20,10 @@ class AccountFiscalPosition(models.Model):
         "on an Invoice",
     )
 
+    is_visible_show_vies_warning = fields.Boolean(
+        "Visible Show Vies Warning", compute="_compute_visible_vies_warning"
+    )
+
     def raise_vies_warning(self, partner_name):
         raise ValidationError(
             _(
@@ -31,3 +35,12 @@ class AccountFiscalPosition(models.Model):
                 "partner_name": partner_name,
             }
         )
+
+    @api.depends("auto_apply", "vat_required", "company_id.vat_check_vies")
+    def _compute_visible_vies_warning(self):
+        for record in self:
+            record.is_visible_show_vies_warning = bool(
+                record.auto_apply
+                and record.vat_required
+                and record.company_id.vat_check_vies
+            )

--- a/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py
+++ b/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py
@@ -111,3 +111,25 @@ class TestFiscalPositionViesWarning(BaseCommon):
         invoice = self._create_invoice(self.partner_vies, self.fp_other)
         invoice.action_post()
         self.assertEqual(invoice.fiscal_position_id.id, self.fp_other.id)
+
+    def test_vies_warning_visibility(self):
+        self.fp_other.auto_apply = True
+        self.fp_other.vat_required = True
+        self.env.company.vat_check_vies = False
+        self.fp_other._compute_visible_vies_warning()
+        self.assertFalse(self.fp_other.is_visible_show_vies_warning)
+
+        self.fp_other.auto_apply = True
+        self.fp_other.vat_required = True
+        self.env.company.vat_check_vies = True
+        self.fp_other._compute_visible_vies_warning()
+        self.assertTrue(self.fp_other.is_visible_show_vies_warning)
+
+        self.fp_other.auto_apply = True
+        self.fp_other.vat_required = False
+        self.fp_other._compute_visible_vies_warning()
+        self.assertFalse(self.fp_other.is_visible_show_vies_warning)
+
+        self.env.company.vat_check_vies = False
+        self.fp_intra_community._compute_visible_vies_warning()
+        self.assertFalse(self.fp_intra_community.is_visible_show_vies_warning)

--- a/account_fiscal_position_vies_warning/views/account_fiscal_position_view.xml
+++ b/account_fiscal_position_vies_warning/views/account_fiscal_position_view.xml
@@ -5,7 +5,11 @@
         <field name="inherit_id" ref="account.view_account_position_form" />
         <field name="arch" type="xml">
             <field name="vat_required" position="after">
-                <field name="is_show_vies_warning" />
+                <field name="is_visible_show_vies_warning" invisible="1" />
+                <field
+                    name="is_show_vies_warning"
+                    invisible="not is_visible_show_vies_warning"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
The “Show VIES warning” field now only appears if the “Automatically detect” and “Requires VAT” checks are enabled and the company has VIES enabled.

MT-13115 @moduon @EmilioPascual 

https://www.loom.com/share/82ddd16d593540d39587f4eec2fd11c1

<img width="2003" height="550" alt="imagen" src="https://github.com/user-attachments/assets/1c64a2a1-a714-4e39-ace0-b7d885f5e023" />
<img width="1878" height="478" alt="imagen" src="https://github.com/user-attachments/assets/292eb3bb-a0d8-464e-b8c8-574386445d32" />
