### PR TITLE
[18.0][FIX] account_avatax_{sale_}oca: Add missing parameter to compute_all function

### DIFF
--- a/account_avatax_oca/models/account_tax.py
+++ b/account_avatax_oca/models/account_tax.py
@@ -62,7 +62,7 @@ class AccountTax(models.Model):
         is_refund=False,
         handle_price_include=True,
         include_caba_tags=False,
-        fixed_multiplicator=1,
+        rounding_method=None,
     ):
         """
         Adopted as the central point to inject custom tax computations.
@@ -79,7 +79,7 @@ class AccountTax(models.Model):
             is_refund,
             handle_price_include,
             include_caba_tags,
-            fixed_multiplicator,
+            rounding_method,
         )
         avatax_invoice = self.env.context.get("avatax_invoice")
         if avatax_invoice:

--- a/account_avatax_sale_oca/models/account_tax.py
+++ b/account_avatax_sale_oca/models/account_tax.py
@@ -14,7 +14,7 @@ class AccountTax(models.Model):
         is_refund=False,
         handle_price_include=True,
         include_caba_tags=False,
-        fixed_multiplicator=1,
+        rounding_method=None,
     ):
         res = super().compute_all(
             price_unit,
@@ -24,8 +24,8 @@ class AccountTax(models.Model):
             partner,
             is_refund,
             handle_price_include,
-            include_caba_tags=False,
-            fixed_multiplicator=fixed_multiplicator,
+            include_caba_tags=include_caba_tags,
+            rounding_method=rounding_method,
         )
         for_avatax_object = self.env.context.get("for_avatax_object")
         if for_avatax_object:


### PR DESCRIPTION
Remove fixed_multiplicator param (Github: https://github.com/odoo/odoo/commit/ab0bdf0192120671010634978f202da35ddfc79f#diff-1ee3fce434db0c4e897973eebf5c1be501196cbd413e6c250ecc973238f939b9L640)
Add rounding_method param (Github: https://github.com/odoo/odoo/commit/cd76aec1f722d32d2bc6c1a13ef73296ce00ecc5#diff-1ee3fce434db0c4e897973eebf5c1be501196cbd413e6c250ecc973238f939b9R1284)