### PR TITLE
[18.0][FIX] account_avatax_oca: update Avalara certification code

### DIFF
--- a/account_avatax_oca/models/avatax_rest_api.py
+++ b/account_avatax_oca/models/avatax_rest_api.py
@@ -30,8 +30,8 @@ class AvaTaxRESTService:
         self.timeout = not config and timeout or config.request_timeout
         self.is_log_enabled = enable_log or config and config.logging
         # Set elements adapter defaults
-        self.appname = "Odoo 17 - Open Source Integrators/OCA"
-        self.version = "a0o5a000007SPdsAAG"
+        self.appname = "Odoo"
+        self.version = "a0nUz00000lVIX3IAO"
         self.hostname = socket.gethostname()
         url = url or (config and config.service_url) or ""
         self.environment = (


### PR DESCRIPTION
Avalara requires the connector to go through re-certification.
This has been done by the OSI team, the new assigned client code should
be added.

Using a connector with a properly certified code is important to be able
to access Avalara's customer support if that is needed.
