### PR TITLE
[FIX] account_fiscal_position_vies_warning: working test

### DIFF
--- a/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py
+++ b/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py
@@ -13,12 +13,37 @@ class TestFiscalPositionViesWarning(BaseCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.company.vat_check_vies = True
+        cls.income_account = cls.env["account.account"].create(
+            {
+                "name": "Test Income",
+                "code": "TESTINC",
+                "account_type": "income",
+                "company_ids": [Command.link(cls.env.company.id)],
+            }
+        )
+        cls.receivable_account = cls.env["account.account"].create(
+            {
+                "name": "Test Receivable",
+                "code": "TESTREC",
+                "account_type": "asset_receivable",
+                "company_ids": [Command.link(cls.env.company.id)],
+            }
+        )
+        cls.sale_journal = cls.env["account.journal"].create(
+            {
+                "name": "Test Sale Journal",
+                "code": "TSJ",
+                "type": "sale",
+                "company_id": cls.env.company.id,
+            }
+        )
         cls.partner_vies = cls.env["res.partner"].create(
             {
                 "name": "Belgium Partner",
                 "country_id": cls.env.ref("base.be").id,
                 "vat": "BE0477472701",
                 "vies_valid": True,
+                "property_account_receivable_id": cls.receivable_account.id,
             }
         )
         cls.partner_not_vies = cls.env["res.partner"].create(
@@ -27,6 +52,7 @@ class TestFiscalPositionViesWarning(BaseCommon):
                 "country_id": cls.env.ref("base.nl").id,
                 "vat": "NL946186650B01",
                 "vies_valid": False,
+                "property_account_receivable_id": cls.receivable_account.id,
             }
         )
         cls.fp_intra_community = cls.env["account.fiscal.position"].create(
@@ -48,11 +74,18 @@ class TestFiscalPositionViesWarning(BaseCommon):
             {
                 "move_type": "out_invoice",
                 "partner_id": partner.id,
+                "journal_id": self.sale_journal.id,
                 "invoice_date": "2025-09-04",
                 "date": "2025-09-04",
                 "fiscal_position_id": fiscal_position.id,
                 "invoice_line_ids": [
-                    Command.create({"name": "line1", "price_unit": 110.0}),
+                    Command.create(
+                        {
+                            "name": "line1",
+                            "price_unit": 110.0,
+                            "account_id": self.income_account.id,
+                        }
+                    ),
                 ],
             }
         )


### PR DESCRIPTION
This module failed when tested isolated:

```
2026-06-05 09:20:52,231 24 ERROR test odoo.addons.account_fiscal_position_vies_warning.tests.test_fiscal_position_vies_warning: ERROR: TestFiscalPositionViesWarning.test_set_intra_community_fiscal_position_to_partner_not_vies
Traceback (most recent call last):
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py", line 89, in test_set_intra_community_fiscal_position_to_partner_not_vies
    invoice = self._create_invoice(
              ^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/account_fiscal_position_vies_warning/tests/test_fiscal_position_vies_warning.py", line 47, in _create_invoice
    return self.env["account.move"].create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/account/models/account_move.py", line 3864, in create
    moves = super().create(vals_list)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/mail/models/mail_thread.py", line 324, in create
    threads = super(MailThread, self).create(vals_list)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/models.py", line 4657, in create
    new_vals_list = self._prepare_create_values(vals_list)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/models.py", line 4808, in _prepare_create_values
    self._add_precomputed_values(result_vals_list)
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/models.py", line 4843, in _add_precomputed_values
    vals[fname] = field.convert_to_write(record[fname], self)
                                         ~~~~~~^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/models.py", line 6686, in __getitem__
    return self._fields[key].__get__(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/fields_relational.py", line 45, in __get__
    return super().__get__(records, owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/fields.py", line 1746, in __get__
    self.compute_value(recs)
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/fields.py", line 1917, in compute_value
    records._compute_field_value(self)
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/mail/models/mail_thread.py", line 484, in _compute_field_value
    return super()._compute_field_value(field)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/models.py", line 4952, in _compute_field_value
    determine(field.compute, self)
  File "testvenv19/lib/python3.12/site-packages/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/account/models/account_move.py", line 886, in _compute_journal_id
    move.journal_id = move._search_default_journal()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "testvenv19/lib/python3.12/site-packages/odoo/addons/account/models/account_move.py", line 922, in _search_default_journal
    raise UserError(error_msg)
odoo.exceptions.UserError: No journal could be found in company My Company for any of those types: sale
```

@moduon MT-14612
