### PR TITLE
[16.0][FIX] account_avatax_oca, account_avatax_sale_oca: support tax included price

### DIFF
--- a/account_avatax_oca/models/account_move.py
+++ b/account_avatax_oca/models/account_move.py
@@ -461,32 +461,45 @@ class AccountMoveLine(models.Model):
         Return the company currency line amount, after discounts,
         to use for Tax calculation.
 
-        Can be used to compute unit price only, using qty=1.
+        Taxes flagged as price included are embedded in ``price_unit``, so the
+        raw line amount is gross and must not be reported as a taxable base.
+        ``price_subtotal`` is the net line total Odoo already computes, and it
+        equals ``price_unit * quantity * (1 - discount / 100)`` when none of the
+        line taxes is price included.
 
-        Code extracted from account/models/account_move.py,
-        from the compute_base_line_taxes() nested function,
-        adjusted to compute line amount instead of unit price.
+        Can be used to compute unit price only, using qty=1.
         """
         self.ensure_one()
         base_line = self
         move = base_line.move_id
         sign = -1 if move.is_inbound() else 1
-        quantity = qty or base_line.quantity
-        base_amount = base_line.price_unit * quantity
-        if base_line.currency_id:
-            price_unit_foreign_curr = (
-                sign * base_amount * (1 - (base_line.discount / 100.0))
+        if not qty:
+            base_amount = base_line.price_subtotal
+        else:
+            discounted_price_unit = base_line.price_unit * (
+                1 - (base_line.discount / 100.0)
             )
+            if base_line.tax_ids:
+                base_amount = base_line.tax_ids.compute_all(
+                    discounted_price_unit,
+                    currency=base_line.currency_id,
+                    quantity=qty,
+                    product=base_line.product_id,
+                    partner=base_line.partner_id,
+                    is_refund=base_line.is_refund,
+                )["total_excluded"]
+            else:
+                base_amount = discounted_price_unit * qty
+        base_amount = sign * base_amount
+        if base_line.currency_id:
             price_unit_comp_curr = base_line.currency_id._convert(
-                price_unit_foreign_curr,
+                base_amount,
                 move.company_id.currency_id,
                 move.company_id,
                 move.date,
             )
         else:
-            price_unit_comp_curr = (
-                sign * base_amount * (1 - (base_line.discount / 100.0))
-            )
+            price_unit_comp_curr = base_amount
         return -price_unit_comp_curr
 
     # Same in v12

--- a/account_avatax_oca/tests/__init__.py
+++ b/account_avatax_oca/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_account_tax
 from . import test_avatax
+from . import test_avatax_base_amount
 from . import test_parter
 from . import test_rest_api

--- a/account_avatax_oca/tests/test_avatax.py
+++ b/account_avatax_oca/tests/test_avatax.py
@@ -63,6 +63,11 @@ class TestAvatax(common.TransactionCase):
                 "company_code": "DEFAULT",
                 "disable_tax_calculation": False,
                 "invoice_calculate_tax": False,
+                # Credentials are placeholders and service_url defaults to the
+                # production endpoint, so document recording must stay off:
+                # button_draft() would otherwise reach the real service through
+                # void_transaction, which is not mocked here.
+                "disable_tax_reporting": True,
             }
         )
         mock_get_avatax_config_company.return_value = avatax_config
@@ -133,6 +138,11 @@ class TestAvatax(common.TransactionCase):
         mock_get_avatax_config_company.assert_called()
         mock_create_transaction.assert_called()
 
+        # Document recording is disabled in this configuration, so the document
+        # type stays provisional and button_draft() voids nothing through the
+        # service. Asserted rather than left implicit, because the document type
+        # is what tells the two scenarios apart.
+        self.assertEqual(self.invoice._get_avatax_doc_type(commit=True), "SalesOrder")
         self.invoice.button_draft()
 
         avatax_config.write(

--- a/account_avatax_oca/tests/test_avatax_base_amount.py
+++ b/account_avatax_oca/tests/test_avatax_base_amount.py
@@ -1,0 +1,292 @@
+# Copyright 2026 FactorLibre
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import Command
+from odoo.tests import common
+
+
+class TestAvataxBaseAmount(common.TransactionCase):
+    """Taxable base reported to AvaTax for price included taxes.
+
+    A tax flagged as ``price_include`` is embedded in ``price_unit``, so the raw
+    line amount is gross. Reporting it as a taxable base overstates both the
+    base and the tax on the AvaTax side, while the Odoo document itself stays
+    balanced, which makes the defect invisible from Odoo alone.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Avatax Base Customer"})
+        tax_vals = {
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "company_id": cls.env.company.id,
+        }
+        cls.tax_included = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 8.75% included", amount=8.75, price_include=True)
+        )
+        cls.tax_excluded = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 8.75% excluded", amount=8.75, price_include=False)
+        )
+        cls.tax_extra_excluded = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 5% excluded", amount=5.0, price_include=False)
+        )
+        cls.tax_zero_included = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 0% included", amount=0.0, price_include=True)
+        )
+        # Same as tax_included but flagged as AvaTax. The invoice path filters
+        # out the taxes it owns before setting the new one, so a flagged tax is
+        # replaced while an unflagged one is kept alongside it.
+        cls.tax_included_avatax = cls.env["account.tax"].create(
+            dict(
+                tax_vals,
+                name="Test 8.75% included AvaTax",
+                amount=8.75,
+                price_include=True,
+                is_avatax=True,
+            )
+        )
+
+    def _create_invoice(self, line_vals, move_type="out_invoice"):
+        return self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": self.partner.id,
+                "invoice_line_ids": [Command.create(vals) for vals in line_vals],
+            }
+        )
+
+    def _line(self, taxes, price_unit=340.0, quantity=1.0, discount=0.0):
+        return {
+            "name": "Test line",
+            "price_unit": price_unit,
+            "quantity": quantity,
+            "discount": discount,
+            "tax_ids": [Command.set(taxes.ids)],
+        }
+
+    def test_01_avatax_amount_price_include(self):
+        """Gross 340 with an 8.75% included tax reports a net base of 312.64."""
+        invoice = self._create_invoice([self._line(self.tax_included)])
+        line = invoice.invoice_line_ids
+        self.assertAlmostEqual(line._get_avatax_amount(), 312.64, places=2)
+        # The gross amount is what the buggy behaviour used to report.
+        self.assertNotAlmostEqual(line._get_avatax_amount(), 340.0, places=2)
+        # And the reported base matches the subtotal Odoo displays (V2).
+        self.assertAlmostEqual(line._get_avatax_amount(), line.price_subtotal, places=2)
+
+    def test_02_avatax_amount_price_exclude(self):
+        """Without a price included tax the reported base does not change.
+
+        This pins backward compatibility: the value must stay equal to the
+        legacy formula ``price_unit * quantity * (1 - discount / 100)``.
+        """
+        invoice = self._create_invoice(
+            [self._line(self.tax_excluded, price_unit=340.0, quantity=3.0)]
+        )
+        line = invoice.invoice_line_ids
+        legacy_amount = line.price_unit * line.quantity * (1 - line.discount / 100.0)
+        self.assertAlmostEqual(line._get_avatax_amount(), legacy_amount, places=2)
+        self.assertAlmostEqual(line._get_avatax_amount(), 1020.0, places=2)
+
+    def test_03_avatax_amount_multi_tax(self):
+        """A line mixing an included and an excluded tax reports the net base.
+
+        This is the case that rules out deciding by a per line
+        ``any(price_include)`` predicate: the predicate is true, yet part of the
+        line taxes is not embedded in the price, so reporting the gross amount
+        with an AvaTax ``taxIncluded`` flag would overstate the base.
+
+        Only the included tax comes out of the base. The excluded one still
+        applies on top of it, which the line total pins.
+        """
+        taxes = self.tax_included | self.tax_extra_excluded
+        invoice = self._create_invoice([self._line(taxes)])
+        line = invoice.invoice_line_ids
+        base = line._get_avatax_amount()
+        # 340 gross / 1.0875 = 312.64 net, the 5% excluded tax does not move it.
+        self.assertAlmostEqual(base, 312.64, places=2)
+        self.assertAlmostEqual(base, line.price_subtotal, places=2)
+        # Adding an excluded tax to the line leaves the taxable base untouched.
+        base_only_included = self._create_invoice(
+            [self._line(self.tax_included)]
+        ).invoice_line_ids._get_avatax_amount()
+        self.assertAlmostEqual(base, base_only_included, places=2)
+        # And the excluded tax is still charged on top: 312.64 + 27.36 + 15.63.
+        self.assertAlmostEqual(line.price_total, 355.63, places=2)
+
+    def test_04_avatax_amount_discount(self):
+        """The net base is computed on the already discounted price."""
+        invoice = self._create_invoice(
+            [self._line(self.tax_included, discount=10.0)],
+        )
+        line = invoice.invoice_line_ids
+        # 340 * 0.9 = 306 gross -> 306 / 1.0875 = 281.38 net
+        self.assertAlmostEqual(line._get_avatax_amount(), 281.38, places=2)
+
+    def test_05_avatax_amount_refund_price_include(self):
+        """A credit note reports the same net base with a negative sign.
+
+        AvaTax requires refund lines to carry a negative amount.
+        """
+        refund = self._create_invoice(
+            [self._line(self.tax_included)], move_type="out_refund"
+        )
+        line = refund.invoice_line_ids
+        # The net base is the same 312.64 the invoice reports, carried negative
+        # because the move is outbound.
+        self.assertAlmostEqual(line.price_subtotal, 312.64, places=2)
+        prepared = line._avatax_prepare_line(sign=1)
+        self.assertLess(prepared["amount"], 0.0)
+        self.assertAlmostEqual(prepared["amount"], -312.64, places=2)
+
+    def test_06_avatax_amount_invoice_sign_positive(self):
+        """A customer invoice reports a positive amount."""
+        invoice = self._create_invoice([self._line(self.tax_included)])
+        prepared = invoice.invoice_line_ids._avatax_prepare_line(sign=1)
+        self.assertAlmostEqual(prepared["amount"], 312.64, places=2)
+
+    def test_07_avatax_amount_qty_one(self):
+        """The documented ``qty`` argument still yields a unit net amount.
+
+        ``_get_avatax_amount`` documents that it can be called with ``qty=1`` to
+        obtain a unit price. No caller does so in this version, but the argument
+        is public API and must keep working, now also net of included taxes.
+        """
+        invoice = self._create_invoice([self._line(self.tax_included, quantity=2.0)])
+        line = invoice.invoice_line_ids
+        # Whole line: 680 gross -> 625.29 net, rounded once for the line.
+        self.assertAlmostEqual(line._get_avatax_amount(), 625.29, places=2)
+        # Single unit: 340 gross -> 312.64 net.
+        self.assertAlmostEqual(line._get_avatax_amount(qty=1), 312.64, places=2)
+
+    def test_08_avatax_amount_no_tax(self):
+        """A line without taxes keeps the plain discounted line amount."""
+        invoice = self._create_invoice(
+            [self._line(self.env["account.tax"], quantity=2.0, discount=25.0)]
+        )
+        line = invoice.invoice_line_ids
+        self.assertAlmostEqual(line._get_avatax_amount(), 510.0, places=2)
+        self.assertAlmostEqual(line._get_avatax_amount(qty=1), 255.0, places=2)
+
+    def test_09_avatax_amount_zero_price_line(self):
+        """A zero priced line with a 0% included tax reports 0 without failing.
+
+        Real production shipping lines look like this, and they are the template
+        ``get_avalara_tax`` copies, so the flag travels to every tax it creates.
+        """
+        invoice = self._create_invoice(
+            [self._line(self.tax_zero_included, price_unit=0.0)]
+        )
+        line = invoice.invoice_line_ids
+        self.assertEqual(line._get_avatax_amount(), 0.0)
+        # The line is still reported, because it has a quantity.
+        prepared_lines = invoice._avatax_prepare_lines()
+        self.assertEqual(len(prepared_lines), 1)
+        self.assertAlmostEqual(prepared_lines[0]["amount"], 0.0, places=2)
+
+    def test_10_avatax_round_trip_stability(self):
+        """The reported base converges when AvaTax writes its tax back.
+
+        The line starts with a tax flagged as AvaTax, so ``_avatax_compute_tax``
+        filters it out and the tax it stores replaces it. With
+        ``invoice_calculate_tax`` the cycle reruns on every save, and the base is
+        derived from whatever tax the line carries at that moment, so it must
+        reach a fixed point instead of drifting.
+
+        The AvaTax tax is modelled as price included because that is the flag of
+        the 0% template it is copied from in the production configuration. See
+        test_12 for what happens when the starting tax is not flagged, and is
+        therefore kept alongside instead of replaced.
+        """
+        invoice = self._create_invoice([self._line(self.tax_included_avatax)])
+        line = invoice.invoice_line_ids
+        bases = []
+        for iteration in range(4):
+            base = line._get_avatax_amount()
+            bases.append(invoice.currency_id.round(base))
+            # AvaTax answers with the tax for that base, and the module derives
+            # the rate as taxCalculated / taxableAmount before storing the tax.
+            tax_calculated = invoice.currency_id.round(base * 0.0875)
+            rate = round(tax_calculated / base * 100, 4) if base else 0.0
+            avatax_tax = self.env["account.tax"].create(
+                {
+                    "name": "AvaTax %s%% (%s)" % (rate, iteration),
+                    "amount_type": "percent",
+                    "amount": rate,
+                    "price_include": True,
+                    "type_tax_use": "sale",
+                    "company_id": self.env.company.id,
+                    "is_avatax": True,
+                }
+            )
+            # price_subtotal depends on tax_ids, so it recomputes on read.
+            line.tax_ids = [Command.set(avatax_tax.ids)]
+        # Once the rate settles the base must stop moving.
+        self.assertEqual(
+            bases[-1],
+            bases[-2],
+            "The taxable base keeps drifting across round trips: %s" % bases,
+        )
+        # And it must stay net, never fall back to the gross amount.
+        self.assertLess(bases[-1], 340.0)
+
+    def test_11_avatax_amount_negative_quantity(self):
+        """A negative quantity line reports a positive amount.
+
+        ``_avatax_prepare_line`` flips the sign explicitly for negative
+        quantities, so the reported amount must stay positive on a customer
+        invoice even though price_subtotal is negative.
+        """
+        invoice = self._create_invoice([self._line(self.tax_included, quantity=-1.0)])
+        line = invoice.invoice_line_ids
+        self.assertLess(line.price_subtotal, 0.0)
+        prepared = line._avatax_prepare_line(sign=1)
+        self.assertGreater(prepared["amount"], 0.0)
+        self.assertAlmostEqual(prepared["amount"], 312.64, places=2)
+
+    def test_12_round_trip_with_accumulated_taxes(self):
+        """Known risk: when the AvaTax tax is added next to a price included
+        one, the reported base drifts downwards on every recomputation.
+
+        The invoice path only filters out the taxes flagged as AvaTax before
+        storing its own (see ``account.move._avatax_compute_tax``), so a tax that
+        is not flagged is kept and the new one lands next to it. If the tax
+        AvaTax creates is price included too -- it inherits that flag from the 0%
+        template it is copied from -- the line ends up with two price included
+        taxes, and Odoo strips both from the base.
+
+        The base then no longer converges: it falls below the correct net amount
+        and keeps falling. This test pins that behaviour so it stays a known
+        limitation of the configuration rather than a surprise. The healthy
+        configurations are covered by test_10.
+        """
+        invoice = self._create_invoice([self._line(self.tax_included)])
+        line = invoice.invoice_line_ids
+        first_base = line._get_avatax_amount()
+        self.assertAlmostEqual(first_base, 312.64, places=2)
+
+        # AvaTax answers for that base, and the module stores its tax alongside
+        # the existing one because the latter is not flagged as AvaTax.
+        rate = round(
+            invoice.currency_id.round(first_base * 0.0875) / first_base * 100, 4
+        )
+        avatax_tax = self.env["account.tax"].create(
+            {
+                "name": "AvaTax %s%%" % rate,
+                "amount_type": "percent",
+                "amount": rate,
+                "price_include": True,
+                "type_tax_use": "sale",
+                "company_id": self.env.company.id,
+                "is_avatax": True,
+            }
+        )
+        line.tax_ids = [Command.set((self.tax_included | avatax_tax).ids)]
+
+        second_base = line._get_avatax_amount()
+        # Both taxes are stripped, so the base drops well below the correct one
+        # (roughly 340 / (1 + 0.0875 + 0.087513)).
+        self.assertLess(second_base, first_base)
+        self.assertNotAlmostEqual(second_base, 312.64, places=2)

--- a/account_avatax_sale_oca/models/sale_order.py
+++ b/account_avatax_sale_oca/models/sale_order.py
@@ -334,9 +334,12 @@ class SaleOrderLine(models.Model):
         else:
             item_code = product.default_code or ("ID:%d" % product.id)
         tax_code = line.product_id.applicable_tax_code_id.name
-        amount = (
-            sign * line.price_unit * line.product_uom_qty * (1 - line.discount / 100.0)
-        )
+        # Taxes flagged as price included are embedded in price_unit, so the raw
+        # line amount is gross and must not be reported as a taxable base.
+        # price_subtotal is the net line total Odoo already computes, and it
+        # equals price_unit * product_uom_qty * (1 - discount / 100) when none of
+        # the line taxes is price included.
+        amount = sign * line.price_subtotal
         # Calculate discount amount
         discount_amount = 0.0
         is_discounted = False

--- a/account_avatax_sale_oca/tests/__init__.py
+++ b/account_avatax_sale_oca/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_sale_order
+from . import test_sale_order_base_amount

--- a/account_avatax_sale_oca/tests/test_sale_order_base_amount.py
+++ b/account_avatax_sale_oca/tests/test_sale_order_base_amount.py
@@ -1,0 +1,148 @@
+# Copyright 2026 FactorLibre
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import Command
+from odoo.tests import common
+
+
+class TestSaleOrderBaseAmount(common.TransactionCase):
+    """Taxable base reported to AvaTax from the sale order path.
+
+    The invoice copies price and taxes from the order line without recomputing
+    them, so both paths have to agree: otherwise the order to invoice channel
+    keeps reporting a gross amount even after the invoice path is fixed.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Avatax Base Customer"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Avatax Base Product", "list_price": 340.0}
+        )
+        tax_vals = {
+            "amount_type": "percent",
+            "type_tax_use": "sale",
+            "company_id": cls.env.company.id,
+        }
+        cls.tax_included = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 8.75% included", amount=8.75, price_include=True)
+        )
+        cls.tax_excluded = cls.env["account.tax"].create(
+            dict(tax_vals, name="Test 8.75% excluded", amount=8.75, price_include=False)
+        )
+
+    def _create_order(self, taxes, price_unit=340.0, quantity=1.0, discount=0.0):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": quantity,
+                            "price_unit": price_unit,
+                            "discount": discount,
+                            "tax_id": [Command.set(taxes.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+
+    def test_01_sale_amount_price_include(self):
+        """Gross 340 with an 8.75% included tax reports a net base of 312.64."""
+        order = self._create_order(self.tax_included)
+        line = order.order_line
+        self.assertAlmostEqual(line._avatax_prepare_line()["amount"], 312.64, places=2)
+        self.assertAlmostEqual(
+            line._avatax_prepare_line()["amount"], line.price_subtotal, places=2
+        )
+        prepared = line._avatax_prepare_line()
+        self.assertAlmostEqual(prepared["amount"], 312.64, places=2)
+
+    def test_02_sale_amount_price_exclude(self):
+        """Without a price included tax the reported base does not change."""
+        order = self._create_order(self.tax_excluded, quantity=3.0)
+        line = order.order_line
+        legacy_amount = (
+            line.price_unit * line.product_uom_qty * (1 - line.discount / 100.0)
+        )
+        self.assertAlmostEqual(
+            line._avatax_prepare_line()["amount"], legacy_amount, places=2
+        )
+
+    def test_03_sale_amount_discount(self):
+        """The net base is computed on the already discounted price."""
+        order = self._create_order(self.tax_included, discount=10.0)
+        line = order.order_line
+        # 340 * 0.9 = 306 gross -> 306 / 1.0875 = 281.38 net
+        self.assertAlmostEqual(line._avatax_prepare_line()["amount"], 281.38, places=2)
+
+    def test_04_sale_amount_quantity(self):
+        """The reported amount is a line total, rounded once for the line.
+
+        The AvaTax ``amount`` field is the total for the line and ``quantity``
+        travels as a separate field, so the quantity must be inside the amount
+        and must not be applied twice.
+        """
+        order = self._create_order(self.tax_included, quantity=2.0)
+        line = order.order_line
+        # 680 gross -> 625.29 net, not 2 * 312.64 = 625.28
+        self.assertAlmostEqual(line._avatax_prepare_line()["amount"], 625.29, places=2)
+        prepared = line._avatax_prepare_line()
+        self.assertAlmostEqual(prepared["amount"], 625.29, places=2)
+        self.assertEqual(prepared["qty"], 2.0)
+
+    def test_05_sale_amount_matches_invoice(self):
+        """The order line and its invoice line report the same amount.
+
+        This is the order to invoice channel: the invoice inherits price and
+        taxes from the order, so a mismatch here means the same sale is reported
+        twice with two different taxable bases.
+        """
+        order = self._create_order(self.tax_included, quantity=2.0)
+        order.action_confirm()
+        invoice = order._create_invoices()
+        order_amount = order.order_line._avatax_prepare_line()["amount"]
+        invoice_amount = invoice.invoice_line_ids._avatax_prepare_line(sign=1)["amount"]
+        self.assertAlmostEqual(order_amount, invoice_amount, places=2)
+        self.assertAlmostEqual(order_amount, 625.29, places=2)
+
+    def test_06_override_line_taxes_documented(self):
+        """Known limitation: an exclusive AvaTax tax breaks the document itself.
+
+        With ``override_line_taxes`` enabled AvaTax replaces the line tax with
+        one of its own, copied from the 0% AvaTax template. If that template is
+        not flagged as price included, Odoo loses the signal that ``price_unit``
+        is gross: its own ``price_subtotal`` starts treating the gross amount as
+        a net base and the order total changes.
+
+        This is a pre-existing defect, independent of the taxable base reported
+        to AvaTax, and no base computation can fix it without touching
+        ``price_unit``. The test pins the behaviour so it stays a known
+        limitation instead of a surprise.
+        """
+        order = self._create_order(self.tax_included)
+        line = order.order_line
+        self.assertAlmostEqual(line.price_subtotal, 312.64, places=2)
+        self.assertAlmostEqual(order.amount_total, 340.0, places=2)
+
+        avatax_exclusive = self.env["account.tax"].create(
+            {
+                "name": "AvaTax 8.75% exclusive",
+                "amount_type": "percent",
+                "amount": 8.75,
+                "price_include": False,
+                "type_tax_use": "sale",
+                "company_id": self.env.company.id,
+                "is_avatax": True,
+            }
+        )
+        line.tax_id = [Command.set(avatax_exclusive.ids)]
+
+        # The document itself now reads the gross amount as a net base.
+        self.assertAlmostEqual(line.price_subtotal, 340.0, places=2)
+        self.assertGreater(order.amount_total, 340.0)
+        # And the reported base mirrors the document, as it must.
+        self.assertAlmostEqual(line._avatax_prepare_line()["amount"], 340.0, places=2)


### PR DESCRIPTION
### **Problem**

The price included tax does not come from US tax rules: the setup is a global shop whose standard is tax inclusive pricing, integrated with Odoo, so the order line carries a gross price_unit with a price included tax while AvaTax is what determines the tax.

Taxes flagged as price_include are embedded in price_unit, so the raw line amount is gross. Both line preparers report that gross amount as the AvaTax taxable base:

  ```python
  # account_avatax_oca/models/account_move.py, _get_avatax_amount
  base_amount = base_line.price_unit * quantity

  # account_avatax_sale_oca/models/sale_order.py, _avatax_prepare_line
  amount = sign * line.price_unit * line.product_uom_qty * (1 - line.discount / 100.0)
  ```

The AvaTax LineItemModel.amount field is documented as "Total amount for this line", and a price included tax is not part of that taxable base. The result is that AvaTax records a  base and a tax that are both overstated, while the Odoo document itself stays balanced — which is what makes the defect hard to notice from Odoo alone.

Worked example, 8.75% tax with price_include=True on a gross unit price of 340:

<pre>  ┌─────────────────────────────┬──────────────┬───────┬────────┐
  │                             │ Taxable base │  Tax  │ Total  │
  ├─────────────────────────────┼──────────────┼───────┼────────┤
  │ Odoo document               │ 312.64       │ 27.36 │ 340.00 │
  ├─────────────────────────────┼──────────────┼───────┼────────┤
  │ Reported to AvaTax (before) │ 340.00       │ 29.75 │ 369.75 │
  ├─────────────────────────────┼──────────────┼───────┼────────┤
  │ Reported to AvaTax (after)  │ 312.64       │ 27.36 │ 340.00 │
  └─────────────────────────────┴──────────────┴───────┴────────┘
</pre>

The derived rate is also corrupted: the module stores taxCalculated / taxableAmount, so the example above yields a stored rate of 8.7529% instead of the real 8.75%.

### **Fix**

Report price_subtotal, the net line total Odoo already computes, instead of recomputing the base from price_unit:

- account.move.line._compute_totals sets price_subtotal = taxes_res['total_excluded']
- sale.order.line._compute_amount sets price_subtotal = amount_untaxed from _compute_taxes()

Reading that field instead of recomputing has two benefits: the reported amount is by construction the same figure the document shows, so it cannot drift from it, and it does not re-enter account.tax.compute_all, which this module patches.

_get_avatax_amount keeps its signature, its sign handling and its currency conversion. The documented qty argument still works and is now also net of included  taxes.

Covered by 18 tests across both modules, including backward compatibility against the previous formula, mixed included and excluded taxes on one line, credit note sign, and a round trip asserting the base converges when AvaTax writes its tax back.

### Why both modules in a single PR

The invoice copies price and taxes from the order line without recomputing them, so the two paths are not independently correct. Splitting the fix leaves the order to invoice  channel broken, which is measurable: with only the account_avatax_sale_oca change applied, the order line reports the net base while the invoice generated from it still reports the gross amount.

  ```
  FAIL: TestSaleOrderBaseAmount.test_05_sale_amount_matches_invoice
  AssertionError: 625.29 != 680.0 within 2 places
  ```

 I can split it into two PRs if preferred, at the cost of that cross-path test.


### **Alternative considered: the taxIncluded flag**

AvaTax LineItemModel does expose taxIncluded ("Indicates whether the amount for this line already includes tax"), and sending the gross amount together with that flag would be a  valid design. It was rejected because it requires deciding, per line, whether the amount is gross, and that decision is not reliable:

- With override_line_taxes enabled, AvaTax replaces the line tax with one of its own, copied from the 0% AvaTax template. If that template is not price included, an any(price_include) predicate reads False on a line whose price_unit is still gross.
- A single boolean cannot describe a line that mixes an included and an excluded tax.


### Note on the third commit
  
 The last commit fixes a pre-existing test in this module rather than the defect above. It is  included because CI cannot pass without it: TestAvatax.test_avatax_compute_tax creates an  avalara.salestax record with placeholder credentials, and service_url defaults to the  production endpoint. get_avatax_config_company and create_transaction are mocked, but  void_transaction is not, so button_draft() reaches the live service and fails  authentication.

This is not a regression from the change above. It reproduces on a clean 16.0 checkout with  none of the files from this PR present, and it fails identically — same traceback, same line  numbers. The green runs of that test are all months old (the most recent is 2026-03-02), while  this branch failed twice on 2026-07-29 with byte-identical trees, so the live service appears to  answer differently now than it used to.

The fix disables document recording, which is what the flag is for in a test setup, so no  request is attempted at all. Because disabling it also makes the document type provisional, that  change of scenario is asserted explicitly rather than left as an invisible side effect.

