### PR TITLE
[18.0] account_tax, account_ecotax_sale: add ecotax only if it matches shipping address country

### DIFF
--- a/account_ecotax/models/account_ecotax_classification.py
+++ b/account_ecotax/models/account_ecotax_classification.py
@@ -82,6 +82,12 @@ class AccountEcotaxClassification(models.Model):
     )
     intrastat_code = fields.Char()
     scale_code = fields.Char()
+    country_ids = fields.Many2many(
+        "res.country",
+        string="Countries",
+        help="Ecotax will be applied when delivered in the listed countries (or all "
+        "countries if empty)",
+    )
 
     @api.depends("ecotax_type")
     def _compute_ecotax_vals(self):

--- a/account_ecotax/models/account_move_line.py
+++ b/account_ecotax/models/account_move_line.py
@@ -46,6 +46,12 @@ class AcountMoveLine(models.Model):
 
     def _get_new_vals_list(self):
         self.ensure_one()
+        if not self.product_id:
+            return []
+        country = (
+            self.move_id.partner_shipping_id.country_id
+            or self.move_id.partner_id.country_id
+        )
         new_vals_list = [
             Command.create(
                 {
@@ -53,11 +59,13 @@ class AcountMoveLine(models.Model):
                     "force_amount_unit": ecotaxline_prod.force_amount,
                 }
             )
-            for ecotaxline_prod in self.product_id.all_ecotax_line_product_ids
+            for ecotaxline_prod in self.product_id._get_country_eligible_classification(
+                country
+            )
         ]
         return new_vals_list
 
-    @api.depends("product_id")
+    @api.depends("product_id", "move_id.partner_id", "move_id.partner_shipping_id")
     def _compute_ecotax_line_ids(self):
         """Unlink and recreate ecotax_lines when modifying the product_id."""
         for line in self:

--- a/account_ecotax/models/ecotax_line_product.py
+++ b/account_ecotax/models/ecotax_line_product.py
@@ -22,14 +22,18 @@ class EcotaxLineProduct(models.Model):
     )
     force_amount = fields.Float(
         digits="Ecotax",
-        help="Force ecotax amount.\n"
-        "Allow to substitute default Ecotax Classification",
+        help="Force ecotax amount.\nAllow to substitute default Ecotax Classification",
     )
     amount = fields.Float(
         digits="Ecotax",
         compute="_compute_ecotax",
         help="Ecotax Amount computed form Classification or forced ecotax amount",
         store=True,
+    )
+    country_ids = fields.Many2many(
+        "res.country",
+        string="Countries",
+        related="classification_id.country_ids",
     )
     display_name = fields.Char(compute="_compute_display_name")
 

--- a/account_ecotax/models/product_product.py
+++ b/account_ecotax/models/product_product.py
@@ -42,7 +42,7 @@ class ProductProduct(models.Model):
     weight_based_ecotax = fields.Float(
         compute="_compute_product_ecotax",
         store=True,
-        help="Ecotax value :\n" "product weight * ecotax coef of Ecotax Classification",
+        help="Ecotax value :\nproduct weight * ecotax coef of Ecotax Classification",
     )
 
     @api.depends("ecotax_line_product_ids", "additional_ecotax_line_product_ids")
@@ -75,21 +75,39 @@ class ProductProduct(models.Model):
     )
     def _compute_product_ecotax(self):
         for product in self:
-            weight_based_ecotax = 0.0
-            fixed_ecotax = 0.0
-            for ecotaxline_prod in product.all_ecotax_line_product_ids:
-                ecotax_cls = ecotaxline_prod.classification_id
-                if ecotax_cls.ecotax_type == "weight_based":
-                    # Recompute ecotaxe amount
-                    # because product weight can be different for variant
-                    amount = ecotax_cls.ecotax_coef * (
-                        product.weight or product.product_tmpl_id.weight or 0.0
-                    )
-                    if ecotaxline_prod.force_amount:
-                        amount = ecotaxline_prod.force_amount
-                    weight_based_ecotax += amount
-                else:
-                    fixed_ecotax += ecotaxline_prod.amount
+            (
+                fixed_ecotax,
+                weight_based_ecotax,
+            ) = product._get_ecotax_amounts_from_classification(
+                product.all_ecotax_line_product_ids
+            )
             product.fixed_ecotax = fixed_ecotax
             product.weight_based_ecotax = weight_based_ecotax
             product.ecotax_amount = fixed_ecotax + weight_based_ecotax
+
+    def _get_ecotax_amounts_from_classification(self, ecotax_lines):
+        self.ensure_one()
+        weight_based_ecotax = 0.0
+        fixed_ecotax = 0.0
+        for ecotaxline_prod in ecotax_lines:
+            ecotax_cls = ecotaxline_prod.classification_id
+            if ecotax_cls.ecotax_type == "weight_based":
+                # Recompute ecotaxe amount
+                # because product weight can be different for variant
+                amount = ecotax_cls.ecotax_coef * (
+                    self.weight or self.product_tmpl_id.weight or 0.0
+                )
+                if ecotaxline_prod.force_amount:
+                    amount = ecotaxline_prod.force_amount
+                weight_based_ecotax += amount
+            else:
+                fixed_ecotax += ecotaxline_prod.amount
+        return fixed_ecotax, weight_based_ecotax
+
+    def _get_country_eligible_classification(self, country):
+        self and self.ensure_one()
+        return self.all_ecotax_line_product_ids.filtered(
+            lambda line: (
+                not line.country_ids or (country and country in line.country_ids)
+            )
+        )

--- a/account_ecotax/tests/test_ecotax.py
+++ b/account_ecotax/tests/test_ecotax.py
@@ -407,6 +407,33 @@ class TestInvoiceEcotaxCommon(BaseCommon):
             variant_2.product_tmpl_id.ecotax_line_product_ids,
         )
 
+    def _test_06_ecotax_by_country(self):
+        """
+        Test default ecotax by country
+        """
+        self.invoice_partner.write({"country_id": self.env.ref("base.fr").id})
+        invoice = self._make_invoice(products=self._make_product(self.ecotax_fixed))
+        # no country ecotax classification is set
+        self.assertEqual(
+            invoice.invoice_line_ids.ecotax_line_ids.classification_id,
+            self.ecotax_fixed,
+        )
+        # in case of wrong country, the ecotax is not set
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.de").id)]}
+        )
+        invoice.write({"partner_id": self.invoice_partner.id})
+        self.assertFalse(invoice.invoice_line_ids.ecotax_line_ids.classification_id)
+        # in case the same country is set, the ecotax is set as well
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.fr").id)]}
+        )
+        invoice.write({"partner_id": self.invoice_partner.id})
+        self.assertEqual(
+            invoice.invoice_line_ids.ecotax_line_ids.classification_id,
+            self.ecotax_fixed,
+        )
+
 
 class TestInvoiceEcotax(TestInvoiceEcotaxCommon):
     def test_01_default_fixed_ecotax(self):
@@ -423,3 +450,6 @@ class TestInvoiceEcotax(TestInvoiceEcotaxCommon):
 
     def test_05_product_variants(self):
         self._test_05_product_variants()
+
+    def test_06_ecotax_by_country(self):
+        self._test_06_ecotax_by_country()

--- a/account_ecotax/views/account_ecotax_classification_view.xml
+++ b/account_ecotax/views/account_ecotax_classification_view.xml
@@ -14,6 +14,7 @@
                 <field name="ecotax_type" />
                 <field name="categ_id" />
                 <field name="product_status" />
+                <field name="country_ids" widget="many2many_tags" optional="hide" />
             </list>
         </field>
     </record>
@@ -50,6 +51,7 @@
                     </group>
                     <separator string="Ecotaxes settings" />
                     <group col="4" name="ecotax_settings">
+                        <field name="country_ids" widget="many2many_tags" />
                         <field name="ecotax_type" />
                         <field
                             name="ecotax_coef"

--- a/account_ecotax/views/product_template_view.xml
+++ b/account_ecotax/views/product_template_view.xml
@@ -21,6 +21,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </list>
                         </field>
                     </div>

--- a/account_ecotax/views/product_view.xml
+++ b/account_ecotax/views/product_view.xml
@@ -26,6 +26,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </list>
                         </field>
                     </div>
@@ -43,6 +44,7 @@
                                 <field name="classification_id" />
                                 <field name="force_amount" />
                                 <field name="amount" />
+                                <field name="country_ids" widget="many2many_tags" />
                             </list>
                         </field>
                     </div>
@@ -73,6 +75,7 @@
                             <field name="classification_id" />
                             <field name="force_amount" />
                             <field name="amount" />
+                            <field name="country_ids" widget="many2many_tags" />
                         </list>
                     </field>
                 </div>

--- a/account_ecotax_sale/models/sale_order_line.py
+++ b/account_ecotax_sale/models/sale_order_line.py
@@ -48,6 +48,12 @@ class SaleOrderLine(models.Model):
 
     def _get_new_vals_list(self):
         self.ensure_one()
+        if not self.product_id:
+            return []
+        country = (
+            self.order_id.partner_shipping_id.country_id
+            or self.order_id.partner_id.country_id
+        )
         new_vals_list = [
             Command.create(
                 {
@@ -55,11 +61,13 @@ class SaleOrderLine(models.Model):
                     "force_amount_unit": ecotaxline_prod.force_amount,
                 }
             )
-            for ecotaxline_prod in self.product_id.all_ecotax_line_product_ids
+            for ecotaxline_prod in self.product_id._get_country_eligible_classification(
+                country
+            )
         ]
         return new_vals_list
 
-    @api.depends("product_id")
+    @api.depends("product_id", "order_id.partner_id", "order_id.partner_shipping_id")
     def _compute_ecotax_line_ids(self):
         """Unlink and recreate ecotax_lines when modifying the product_id."""
         for line in self:

--- a/account_ecotax_sale/tests/test_sale_ecotax.py
+++ b/account_ecotax_sale/tests/test_sale_ecotax.py
@@ -2,6 +2,7 @@
 #   @author Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import Command
 from odoo.tests import Form
 
 from odoo.addons.account_ecotax.tests.test_ecotax import TestInvoiceEcotaxCommon
@@ -107,6 +108,37 @@ class TestsaleEcotaxCommon(TestInvoiceEcotaxCommon):
         self.assertEqual(self.sale.amount_untaxed, 1000.0)
         self.assertEqual(self.sale.amount_ecotax, 47.0)
 
+    def _test_03_ecotax_by_country(self):
+        """
+        Test default ecotax by country
+        """
+        partner12 = self.env.ref("base.res_partner_12")
+        partner12.write({"country_id": self.env.ref("base.fr").id})
+        sale = self.create_sale_partner(
+            partner_id=partner12, products_and_qty=[(self.product_a, 1.0)]
+        )
+        # computed ecotax lines are not persisted through the Form in 18.0,
+        # trigger the compute explicitly (same pattern as test_01/test_02)
+        sale.order_line._compute_ecotax_line_ids()
+        # no country ecotax classification is set, ecotax is taken by default
+        self.assertEqual(
+            sale.order_line.ecotax_line_ids.classification_id, self.ecotax_fixed
+        )
+        # in case of wrong country, the ecotax is not set
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.de").id)]}
+        )
+        sale.write({"partner_id": partner12.id})
+        self.assertFalse(sale.order_line.ecotax_line_ids.classification_id)
+        # in case the same country is set, the ecotax is set as well
+        self.ecotax_fixed.write(
+            {"country_ids": [Command.link(self.env.ref("base.fr").id)]}
+        )
+        sale.write({"partner_id": sale.partner_id.id})
+        self.assertEqual(
+            sale.order_line.ecotax_line_ids.classification_id, self.ecotax_fixed
+        )
+
 
 class TestsaleEcotax(TestsaleEcotaxCommon):
     def test_01_classification_weight_based_ecotax(self):
@@ -114,3 +146,6 @@ class TestsaleEcotax(TestsaleEcotaxCommon):
 
     def test_02_classification_ecotax(self):
         self._test_02_classification_ecotax()
+
+    def test_03_ecotax_by_country(self):
+        self._test_03_ecotax_by_country()


### PR DESCRIPTION
Forward-port to 18.0 of the ecotax-by-country feature merged in 16.0 by
Florian da Costa (OCA#501), following the unmerged 17.0 port attempt
OCA#514. Split into 2 commits, one per module:

- account_ecotax: `country_ids` on account.ecotax.classification (empty =
  all countries), `_get_country_eligible_classification()` on
  product.product, ecotax lines filtered by the delivery
  (partner_shipping/partner) country on invoice lines, helper
  `_get_ecotax_amounts_from_classification()` extracted. Includes the
  c482033d reliability fix (`self and self.ensure_one()`) from the 16.0
  merged state. New test_06_ecotax_by_country.
- account_ecotax_sale: same country filtering on sale order lines,
  new test_03_ecotax_by_country.

Adaptations to 18.0:
- weight-based ecotax amounts are still recomputed from the product weight
  (18.0 behavior, kept inside the extracted helper)
- the sale test triggers `_compute_ecotax_line_ids()` explicitly after Form
  save, following the existing test_01/test_02 pattern (computed O2m is not
  persisted through Form in 18.0)

The account_ecotax_tax / account_ecotax_sale_tax country support (also part
of OCA#501 in 16.0, with a different computation approach on 18.0) will be
proposed in a follow-up PR.
